### PR TITLE
Validate call arguments

### DIFF
--- a/src/main/groovy/nextflow/lsp/ast/ASTUtils.java
+++ b/src/main/groovy/nextflow/lsp/ast/ASTUtils.java
@@ -277,8 +277,7 @@ public class ASTUtils {
         var minCount = Math.min(paramsCount, argsCount);
 
         int score = 0;
-        if( minCount == 0 && paramsCount == argsCount )
-            score++;
+        score -= Math.abs(paramsCount - argsCount);
 
         for( int i = 0; i < minCount; i++ ) {
             var paramType = (i < paramsCount) ? parameters[i].getType() : null;
@@ -289,11 +288,6 @@ public class ASTUtils {
                     score += 1000;
                 else if( argType.isDerivedFrom(paramType) )
                     score += 100;
-                else
-                    score++;
-            }
-            else if( paramType != null ) {
-                score++;
             }
         }
         return score;

--- a/src/main/groovy/nextflow/lsp/services/script/CallArgumentsException.java
+++ b/src/main/groovy/nextflow/lsp/services/script/CallArgumentsException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lsp.services.script;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.syntax.SyntaxException;
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public class CallArgumentsException extends SyntaxException {
+
+    public CallArgumentsException(String message, ASTNode node) {
+        super(message, node);
+    }
+}

--- a/src/main/groovy/nextflow/script/v2/IncludeVariable.java
+++ b/src/main/groovy/nextflow/script/v2/IncludeVariable.java
@@ -50,12 +50,12 @@ public class IncludeVariable extends ASTNode implements Variable {
 
     @Override
     public ClassNode getType() {
-        return method.getReturnType();
+        return method != null ? method.getReturnType() : null;
     }
 
     @Override
     public ClassNode getOriginType() {
-        return method.getReturnType();
+        return method != null ? method.getReturnType() : null;
     }
 
     @Override
@@ -80,7 +80,7 @@ public class IncludeVariable extends ASTNode implements Variable {
 
     @Override
     public boolean isDynamicTyped() {
-        return method.isDynamicReturnType();
+        return method != null && method.isDynamicReturnType();
     }
 
     @Override


### PR DESCRIPTION
Validate the number of arguments for process and workflow calls. Validating all function calls will require type checking, but we could probably go ahead with this piece.