### PR TITLE
Use related information for error diagnostics

### DIFF
--- a/src/main/groovy/nextflow/lsp/services/script/RedeclaredVariableException.java
+++ b/src/main/groovy/nextflow/lsp/services/script/RedeclaredVariableException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lsp.services.script;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.syntax.SyntaxException;
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public class RedeclaredVariableException extends SyntaxException {
+
+    private ASTNode other;
+
+    public RedeclaredVariableException(String message, ASTNode node, ASTNode other) {
+        super(message, node);
+        this.other = other;
+    }
+
+    public ASTNode getOtherDeclaration() {
+        return other;
+    }
+}

--- a/src/main/groovy/nextflow/lsp/services/script/VariableScopeVisitor.groovy
+++ b/src/main/groovy/nextflow/lsp/services/script/VariableScopeVisitor.groovy
@@ -131,8 +131,10 @@ class VariableScopeVisitor extends ClassCodeVisitorSupport implements ScriptVisi
     private void declare(Variable variable, ASTNode context) {
         VariableScope scope = currentScope
         while( scope != null ) {
-            if( variable.name in scope.getDeclaredVariables() ) {
-                addError("`${variable.name}` is already declared", context)
+            final other = scope.getDeclaredVariable(variable.name)
+            if( other != null ) {
+                final otherNode = other instanceof ASTNode ? (ASTNode) other : null
+                addError(new RedeclaredVariableException("`${variable.name}` is already declared", context, otherNode))
                 break
             }
             scope = scope.parent
@@ -807,7 +809,10 @@ class VariableScopeVisitor extends ClassCodeVisitorSupport implements ScriptVisi
 
     @Override
     void addError(String message, ASTNode node) {
-        final cause = new SyntaxException(message, node)
+        addError(new SyntaxException(message, node))
+    }
+
+    protected void addError(SyntaxException cause) {
         final errorMessage = new SyntaxErrorMessage(cause, sourceUnit)
         sourceUnit.getErrorCollector().addErrorAndContinue(errorMessage)
     }


### PR DESCRIPTION
This PR shows how to attach "related information" to a diagnostic, in this case to point to a variable that was already declared in the same scope.

Holding this for now since I might overhaul the error system first. Also curious to see if I think of any other use cases for this feature.