### PR TITLE
Signature help

### DIFF
--- a/src/main/groovy/nextflow/lsp/NextflowLanguageServer.java
+++ b/src/main/groovy/nextflow/lsp/NextflowLanguageServer.java
@@ -78,6 +78,9 @@ import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.SetTraceParams;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpOptions;
+import org.eclipse.lsp4j.SignatureHelpParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextEdit;
@@ -163,6 +166,8 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
         serverCapabilities.setHoverProvider(true);
         serverCapabilities.setReferencesProvider(true);
         serverCapabilities.setRenameProvider(true);
+        var signatureHelpOptions = new SignatureHelpOptions(List.of("(", ","));
+        serverCapabilities.setSignatureHelpProvider(signatureHelpOptions);
         serverCapabilities.setWorkspaceSymbolProvider(true);
 
         var initializeResult = new InitializeResult(serverCapabilities);
@@ -403,6 +408,20 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
             if( service == null )
                 return null;
             return service.rename(params);
+        });
+    }
+
+	@Override
+	public CompletableFuture<SignatureHelp> signatureHelp(SignatureHelpParams params) {
+        return CompletableFutures.computeAsync((cancelChecker) -> {
+            cancelChecker.checkCanceled();
+            var uri = params.getTextDocument().getUri();
+            var position = params.getPosition();
+            log.debug(String.format("textDocument/signatureHelp %s [ %d, %d ]", relativePath(uri), position.getLine(), position.getCharacter()));
+            var service = getLanguageService(uri);
+            if( service == null )
+                return null;
+            return service.signatureHelp(params);
         });
     }
 

--- a/src/main/groovy/nextflow/lsp/services/LanguageService.java
+++ b/src/main/groovy/nextflow/lsp/services/LanguageService.java
@@ -72,6 +72,8 @@ import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -115,6 +117,7 @@ public abstract class LanguageService {
     protected LinkProvider getLinkProvider() { return null; }
     protected ReferenceProvider getReferenceProvider() { return null; }
     protected RenameProvider getRenameProvider() { return null; }
+    protected SignatureHelpProvider getSignatureHelpProvider() { return null; }
     protected SymbolProvider getSymbolProvider() { return null; }
 
     private volatile boolean initialized;
@@ -292,6 +295,15 @@ public abstract class LanguageService {
             return null;
 
         return provider.rename(params.getTextDocument(), params.getPosition(), params.getNewName());
+    }
+
+	public SignatureHelp signatureHelp(SignatureHelpParams params) {
+        var provider = getSignatureHelpProvider();
+        if( provider == null )
+            return null;
+
+        updateNow();
+        return provider.signatureHelp(params.getTextDocument(), params.getPosition(), params.getContext());
     }
 
     public List<? extends WorkspaceSymbol> symbol(WorkspaceSymbolParams params) {

--- a/src/main/groovy/nextflow/lsp/services/SignatureHelpProvider.java
+++ b/src/main/groovy/nextflow/lsp/services/SignatureHelpProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lsp.services;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpContext;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+public interface SignatureHelpProvider {
+
+    SignatureHelp signatureHelp(TextDocumentIdentifier textDocument, Position position, SignatureHelpContext context);
+
+}

--- a/src/main/groovy/nextflow/lsp/services/script/ScriptService.java
+++ b/src/main/groovy/nextflow/lsp/services/script/ScriptService.java
@@ -29,6 +29,7 @@ import nextflow.lsp.services.LanguageService;
 import nextflow.lsp.services.LinkProvider;
 import nextflow.lsp.services.ReferenceProvider;
 import nextflow.lsp.services.RenameProvider;
+import nextflow.lsp.services.SignatureHelpProvider;
 import nextflow.lsp.services.SymbolProvider;
 
 /**
@@ -93,6 +94,11 @@ public class ScriptService extends LanguageService {
     @Override
     protected RenameProvider getRenameProvider() {
         return new ScriptReferenceProvider(astCache);
+    }
+
+    @Override
+    protected SignatureHelpProvider getSignatureHelpProvider() {
+        return new ScriptSignatureHelpProvider(astCache);
     }
 
     @Override

--- a/src/main/groovy/nextflow/lsp/services/script/ScriptSignatureHelpProvider.java
+++ b/src/main/groovy/nextflow/lsp/services/script/ScriptSignatureHelpProvider.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lsp.services.script;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import nextflow.lsp.ast.ASTNodeStringUtils;
+import nextflow.lsp.ast.ASTUtils;
+import nextflow.lsp.services.SignatureHelpProvider;
+import nextflow.lsp.services.util.CustomFormattingOptions;
+import nextflow.lsp.services.util.Formatter;
+import nextflow.lsp.util.Logger;
+import nextflow.script.v2.ProcessNode;
+import nextflow.script.v2.WorkflowNode;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.MethodCall;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
+import org.eclipse.lsp4j.ParameterInformation;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpContext;
+import org.eclipse.lsp4j.SignatureInformation;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+import static nextflow.script.v2.ASTHelpers.*;
+
+public class ScriptSignatureHelpProvider implements SignatureHelpProvider {
+
+    private static Logger log = Logger.getInstance();
+
+    private ScriptAstCache ast;
+
+    public ScriptSignatureHelpProvider(ScriptAstCache ast) {
+        this.ast = ast;
+    }
+
+    @Override
+    public SignatureHelp signatureHelp(TextDocumentIdentifier textDocument, Position position, SignatureHelpContext context) {
+        if( ast == null ) {
+            log.error("ast cache is empty while providing signature help");
+            return null;
+        }
+
+        var uri = URI.create(textDocument.getUri());
+        var offsetNode = ast.getNodeAtLineAndColumn(uri, position.getLine(), position.getCharacter());
+        if( offsetNode == null )
+            return null;
+
+        var call = getMethodCall(offsetNode);
+        if( call == null )
+            return null;
+
+        var result = context.getActiveSignatureHelp();
+        if( result == null )
+            result = astNodeToSignatureHelp(call);
+
+        var activeParameter = getActiveParameter(offsetNode, call);
+        var activeSignature = getActiveSignature(call, activeParameter);
+        result.setActiveSignature(activeSignature);
+        result.setActiveParameter(activeParameter);
+        return result;
+    }
+
+    private MethodCall getMethodCall(ASTNode node) {
+        if( node instanceof MethodCall call ) {
+            return call;
+        }
+
+        if( node instanceof ArgumentListExpression ) {
+            return getMethodCall(ast.getParent(node));
+        }
+
+        ASTNode current = node;
+        while( current != null ) {
+            if( current instanceof MethodCall call )
+                return call;
+            current = ast.getParent(current);
+        }
+        return null;
+    }
+
+    private SignatureHelp astNodeToSignatureHelp(MethodCall call) {
+        var methods = ASTUtils.getMethodOverloadsFromCallExpression(call, ast);
+        var signatures = methods.stream()
+            .map((mn) -> {
+                var documentation = ASTNodeStringUtils.getDocumentation(mn);
+                var si = new SignatureInformation(
+                    ASTNodeStringUtils.getLabel(mn, ast),
+                    documentation != null ? new MarkupContent(MarkupKind.MARKDOWN, documentation) : null,
+                    getParameterInfo(mn)
+                );
+                return si;
+            })
+            .collect(Collectors.toList());
+        return new SignatureHelp(signatures, 0, 0);
+    }
+
+    private List<ParameterInformation> getParameterInfo(MethodNode mn) {
+        if( mn instanceof ProcessNode pn ) {
+            return asDirectives(pn.inputs)
+                .map((call) -> {
+                    var fmt = new Formatter(new CustomFormattingOptions(0, false, false));
+                    fmt.append(call.getMethodAsString());
+                    fmt.append(' ');
+                    fmt.visitArguments(asMethodCallArguments(call), hasNamedArgs(call), false);
+                    var label = fmt.toString();
+                    var documentation = new MarkupContent(MarkupKind.MARKDOWN, "```groovy\n" + label + "\n```");
+                    return new ParameterInformation(label, documentation);
+                })
+                .collect(Collectors.toList());
+        }
+
+        if( mn instanceof WorkflowNode wn ) {
+            return asBlockStatements(wn.takes).stream()
+                .map((take) -> {
+                    var varX = asVarX(take);
+                    return new ParameterInformation(varX.getName(), varX.getName());
+                })
+                .collect(Collectors.toList());
+        }
+
+        return Arrays.stream(mn.getParameters())
+            .map(p -> new ParameterInformation(ASTNodeStringUtils.toString(p, ast)))
+            .collect(Collectors.toList());
+    }
+
+    private int getActiveParameter(ASTNode node, MethodCall call) {
+        var args = asMethodCallArguments(call);
+        if( node == call || node == call.getArguments() ) {
+            return args.size();
+        }
+        for( int i = 0; i < args.size(); i++ ) {
+            if( contains(args.get(i), node) )
+                return i;
+        }
+        return -1;
+    }
+
+    private static boolean contains(ASTNode a, ASTNode b) {
+        return a.getLineNumber() <= b.getLineNumber()
+            && a.getColumnNumber() <= b.getColumnNumber()
+            && b.getLastLineNumber() <= a.getLastLineNumber()
+            && b.getLastColumnNumber() <= a.getLastColumnNumber();
+    }
+
+    private int getActiveSignature(MethodCall call, int activeParameter) {
+        var methods = ASTUtils.getMethodOverloadsFromCallExpression(call, ast);
+        if( methods.size() == 1 )
+            return 0;
+        var best = ASTUtils.getMethodFromCallExpression(call, ast, activeParameter);
+        return methods.indexOf(best);
+    }
+
+}


### PR DESCRIPTION
Adds a basic implementation of signature help for functions, processes, and workflows.

When you type a method name and then `(`, vscode will show the method signature and docs (similar to hover hint). As you type each argument followed by a comma, the current parameter is highlighted, and can also show docs for each parameter. We could pull param docs from inline comments or `@param` directives in the method's groovydoc comment.

My main concern with the current impl is that process inputs don't quite fit the expectations of signature help, which expects a conventional signature of `func(param1, param2, param3, ...)`, whereas process inputs are a bit more complex.

I tried to do a multi-line signature for processes to space out the inputs, but vscode still squashes it onto a single line.

Another thing I could try is to do something like `PROC( <1>, <2>, <3>, <4> )` for the signature and then show the full spec below that for the current input, which should be possible with the label / documentation of `ParameterInfo`. But for some reason, the param documentation is only showing for the first param and then goes away. If I can fix this issue, that might be good enough.

Long term, I think the problem will go away with typed process inputs, which should look more like function / workflow inputs:
```groovy
def func(a: int, b: String, c: boolean) {
  // ...
}

process PROC {
  input:
  meta: String
  reads: Path

  // ...
}

workflow FLOW {
  take:
  samplesheet: Path
  outdir: Path

  // ...
}
```