### PR TITLE
Update workflow outputs to second preview

### DIFF
--- a/src/main/groovy/nextflow/config/dsl/ConfigSchema.java
+++ b/src/main/groovy/nextflow/config/dsl/ConfigSchema.java
@@ -67,7 +67,8 @@ public class ConfigSchema {
         new WaveHttpConfig(),
         new WaveRetryConfig(),
         new WaveSpackConfig(),
-        new WorkflowConfig()
+        new WorkflowConfig(),
+        new WorkflowOutputsConfig()
     );
 
     public static final Map<String, ConfigScope> SCOPES = getConfigScopes();

--- a/src/main/groovy/nextflow/config/scopes/UnscopedConfig.java
+++ b/src/main/groovy/nextflow/config/scopes/UnscopedConfig.java
@@ -47,6 +47,11 @@ public class UnscopedConfig implements ConfigScope {
     public boolean dumpHashes;
 
     @ConfigOption("""
+        Defines the pipeline output directory. Equivalent to the `-output-dir` option of the `run` command.
+    """)
+    public String outputDir;
+
+    @ConfigOption("""
         If `true`, enable the use of previously cached task executions. Equivalent to the `-resume` option of the `run` command.
     """)
     public boolean resume;

--- a/src/main/groovy/nextflow/config/scopes/WorkflowOutputsConfig.java
+++ b/src/main/groovy/nextflow/config/scopes/WorkflowOutputsConfig.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.config.scopes;
+
+import java.util.Map;
+
+import nextflow.config.dsl.ConfigOption;
+import nextflow.config.dsl.ConfigScope;
+
+public class WorkflowOutputsConfig implements ConfigScope {
+
+    public WorkflowOutputsConfig() {}
+
+    @Override
+    public String name() {
+        return "workflow.outputs";
+    }
+
+    @Override
+    public String description() {
+        return """
+            The `workflow.outputs` scope provides options for workflow publishing.
+
+            [Read more](https://nextflow.io/docs/latest/reference/config.html#workflow)
+            """;
+    }
+
+    @ConfigOption("""
+        Set the top-level output directory of the workflow. Defaults to the launch directory (`workflow.launchDir`).
+    """)
+    public String directory;
+
+    @ConfigOption("""
+        *Currently only supported for S3.*
+
+        Specify the media type a.k.a. [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types) of published files (default: `false`). Can be a string (e.g. `'text/html'`), or `true` to infer the content type from the file extension.
+    """)
+    public Object contentType;
+
+    @ConfigOption("""
+        Enable or disable publishing (default: `true`).
+    """)
+    public boolean enabled;
+
+    @ConfigOption("""
+        When `true`, the workflow will not fail if a file can't be published for some reason (default: `false`).
+    """)
+    public boolean ignoreErrors;
+
+    @ConfigOption("""
+        The file publishing method (default: `'symlink'`).
+    """)
+    public String mode;
+
+    @ConfigOption("""
+        When `true` any existing file in the specified folder will be overwritten (default: `'standard'`).
+    """)
+    public Object overwrite;
+
+    @ConfigOption("""
+        *Currently only supported for S3.*
+
+        Specify the storage class for published files.
+    """)
+    public String storageClass;
+
+    @ConfigOption("""
+        *Currently only supported for S3.*
+
+        Specify arbitrary tags for published files.
+    """)
+    public Map<String,String> tags;
+
+}

--- a/src/main/groovy/nextflow/lsp/services/script/VariableScopeVisitor.java
+++ b/src/main/groovy/nextflow/lsp/services/script/VariableScopeVisitor.java
@@ -487,23 +487,13 @@ public class VariableScopeVisitor extends ScriptVisitorSupport {
         block.setVariableScope(currentScope);
 
         asDirectives(block).forEach((call) -> {
-            // treat as regular directive
-            var name = call.getMethodAsString();
-            var variable = findClassMember(currentScope.getClassScope(), name, call.getMethod());
-            if( variable != null ) {
-                visit(call);
-                return;
-            }
-
-            // treat as target definition
             var code = asDslBlock(call, 1);
-            if( code != null ) {
-                checkDirectives(code, OutputDsl.TargetDsl.class, "output target directive");
-                visitTargetBody(code);
+            if( code == null ) {
+                addError("Invalid output directive", call);
                 return;
             }
-
-            addError("Invalid output directive `" + name + "`", call);
+            checkDirectives(code, OutputDsl.TargetDsl.class, "output target directive");
+            visitTargetBody(code);
         });
     }
 

--- a/src/main/groovy/nextflow/script/dsl/OutputDsl.groovy
+++ b/src/main/groovy/nextflow/script/dsl/OutputDsl.groovy
@@ -30,60 +30,6 @@ class OutputDsl implements DslScope {
     ''')
     Map<String,Object> params
 
-    @Function('''
-        Set the top-level output directory of the workflow. Defaults to the launch directory (`workflow.launchDir`).
-    ''')
-    void directory(String value) {
-    }
-
-    @Function('''
-        *Currently only supported for S3.*
-
-        Specify the media type a.k.a. [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types) of published files (default: `false`). Can be a string (e.g. `'text/html'`), or `true` to infer the content type from the file extension.
-    ''')
-    void contentType(value) {
-    }
-
-    @Function('''
-        Enable or disable publishing (default: `true`).
-    ''')
-    void enabled(boolean value) {
-    }
-
-    @Function('''
-        When `true`, the workflow will not fail if a file can't be published for some reason (default: `false`).
-    ''')
-    void ignoreErrors(boolean value) {
-    }
-
-    @Function('''
-        The file publishing method (default: `'symlink'`).
-    ''')
-    void mode(String value) {
-    }
-
-    @Function('''
-        When `true` any existing file in the specified folder will be overwritten (default: `'standard'`).
-    ''')
-    void overwrite(value) {
-    }
-
-    @Function('''
-        *Currently only supported for S3.*
-
-        Specify the storage class for published files.
-    ''')
-    void storageClass(String value) {
-    }
-
-    @Function('''
-        *Currently only supported for S3.*
-
-        Specify arbitrary tags for published files.
-    ''')
-    void tags(Map value) {
-    }
-
     static class TargetDsl implements DslScope {
 
         @Function('''


### PR DESCRIPTION
To merge when Nextflow 24.10 is released

For now, maybe include in a separate v1.1 release so that we have:
- v1.0.x requires Nextflow >=24.04
- v1.1.x requires Nextflow >=24.10