### PR TITLE
Allow trailing dot on arbitrary expressions

### DIFF
--- a/modules/compiler/src/main/antlr/ScriptParser.g4
+++ b/modules/compiler/src/main/antlr/ScriptParser.g4
@@ -321,22 +321,17 @@ assertStatement
 
 // -- variable declaration
 variableDeclaration
-    :   (DEF | legacyType | DEF legacyType) identifier (nls ASSIGN nls initializer=expressionOrIncomplete)?
-    |   DEF variableNames nls ASSIGN nls initializer=expressionOrIncomplete
+    :   (DEF | legacyType | DEF legacyType) identifier (nls ASSIGN nls initializer=expression)?
+    |   DEF variableNames nls ASSIGN nls initializer=expression
     ;
 
 variableNames
     :   LPAREN identifier (COMMA identifier)+ rparen
     ;
 
-expressionOrIncomplete
-    :   expression
-    |   incompleteExpression
-    ;
-
 // -- assignment statement
 multipleAssignmentStatement
-    :   variableNames nls ASSIGN nls expressionOrIncomplete
+    :   variableNames nls ASSIGN nls expression
     ;
 
 assignmentStatement
@@ -356,7 +351,7 @@ assignmentStatement
         |   POWER_ASSIGN
         |   ELVIS_ASSIGN
         ) nls
-        right=expressionOrIncomplete
+        right=expression
     ;
 
 // -- expression statement
@@ -367,7 +362,6 @@ expressionStatement
         |
             /* only certain expressions can be called as a directive (no parens) */
         )
-    |   incompleteExpression
     ;
 
 
@@ -442,6 +436,9 @@ expression
         |   ELVIS nls
         )
         fb=expression                                                                       #conditionalExprAlt
+
+    // incomplete expression
+    |   expression nls (DOT | SPREAD_DOT | SAFE_DOT)                                        #incompleteExprAlt
     ;
 
 primary
@@ -630,11 +627,6 @@ argumentListElement
 
 namedArg
     :   namedProperty COLON expression
-    ;
-
-// -- incomplete expression
-incompleteExpression
-    :   expression nls (DOT | SPREAD_DOT | SAFE_DOT)
     ;
 
 //

--- a/modules/compiler/src/main/antlr/ScriptParser.g4
+++ b/modules/compiler/src/main/antlr/ScriptParser.g4
@@ -321,17 +321,22 @@ assertStatement
 
 // -- variable declaration
 variableDeclaration
-    :   (DEF | legacyType | DEF legacyType) identifier (nls ASSIGN nls initializer=expression)?
-    |   DEF variableNames nls ASSIGN nls initializer=expression
+    :   (DEF | legacyType | DEF legacyType) identifier (nls ASSIGN nls initializer=expressionOrIncomplete)?
+    |   DEF variableNames nls ASSIGN nls initializer=expressionOrIncomplete
     ;
 
 variableNames
     :   LPAREN identifier (COMMA identifier)+ rparen
     ;
 
+expressionOrIncomplete
+    :   expression
+    |   incompleteExpression
+    ;
+
 // -- assignment statement
 multipleAssignmentStatement
-    :   variableNames nls ASSIGN nls expression
+    :   variableNames nls ASSIGN nls expressionOrIncomplete
     ;
 
 assignmentStatement
@@ -351,7 +356,7 @@ assignmentStatement
         |   POWER_ASSIGN
         |   ELVIS_ASSIGN
         ) nls
-        right=expression
+        right=expressionOrIncomplete
     ;
 
 // -- expression statement
@@ -362,6 +367,7 @@ expressionStatement
         |
             /* only certain expressions can be called as a directive (no parens) */
         )
+    |   incompleteExpression
     ;
 
 
@@ -436,9 +442,6 @@ expression
         |   ELVIS nls
         )
         fb=expression                                                                       #conditionalExprAlt
-
-    // incomplete expression
-    |   incompleteExpression                                                                #incompleteExprAlt
     ;
 
 primary
@@ -631,7 +634,7 @@ namedArg
 
 // -- incomplete expression
 incompleteExpression
-    :   identifier (DOT identifier)* DOT
+    :   expression nls (DOT | SPREAD_DOT | SAFE_DOT)
     ;
 
 //


### PR DESCRIPTION
Enables auto-completion on more kinds of expressions, for example:

```groovy
Channel.of(1, 2, 3). // map, filter, collect...
```

The challenge is that `expression` also allows `incompleteExpression`, but the inner expression of `incompleteExpression` should not allow further incomplete expressions.

The current changes to the script parser feel messy and also are incomplete. It would probably be better to parametrize the `expression` rule with a flag for whether the `incompleteExpression` is allowed.