### PR TITLE
Add shims for standard types

### DIFF
--- a/modules/compiler/src/main/java/script/dsl/ScriptDsl.java
+++ b/modules/compiler/src/main/java/script/dsl/ScriptDsl.java
@@ -100,8 +100,7 @@ public interface ScriptDsl extends DslScope {
     @Description("""
         Get one or more files from a path or glob pattern. Returns a Path or list of Paths if there are multiple files.
     """)
-    /* Path | Collection<Path> */
-    Object file(Map<String,?> opts, String filePattern);
+    Path file(Map<String,?> opts, String filePattern);
 
     @Description("""
         Convenience method for `file()` that always returns a list.

--- a/modules/compiler/src/main/java/script/types/Iterable.java
+++ b/modules/compiler/src/main/java/script/types/Iterable.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.types;
+
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import nextflow.script.dsl.Description;
+
+@Description("""
+    An iterable is a common interface for collections that support iteration.
+
+    [Read more](https://nextflow.io/docs/latest/reference/stdlib.html#iterable)
+""")
+public interface Iterable<E> {
+
+    @Description("""
+        Returns `true` if any value in the iterable satisfies the given condition.
+    """)
+    boolean any(Predicate<E> predicate);
+
+    @Description("""
+        Returns a new iterable with each value transformed by the given closure.
+    """)
+    <R> Iterable<R> collect(Function<E,R> mapper);
+
+    @Description("""
+        Invoke the given closure for each value in the iterable.
+    """)
+    void each(Consumer<E> action);
+
+    @Description("""
+        Returns `true` if every value in the iterable satisfies the given condition.
+    """)
+    boolean every(Predicate<E> predicate);
+
+    @Description("""
+        Returns the values in the iterable that satisfy the given condition.
+    """)
+    Iterable<E> findAll(Predicate<E> predicate);
+
+    @Description("""
+        Returns a new iterable with each value transformed by the given closure.
+    """)
+    <R> R inject(R initialValue, BiFunction<R,E,R> accumulator);
+
+    @Description("""
+        Returns the number of values in the iterable.
+    """)
+    int size();
+
+    @Description("""
+        Returns a sorted list of the iterable's values.
+    """)
+    List<E> sort();
+
+    @Description("""
+        Returns the sum of the values in the iterable. The values should support the `+` operator.
+    """)
+    E sum();
+
+    @Description("""
+        Converts the iterable to a set. Duplicate values are excluded.
+    """)
+    Set<E> toSet();
+
+}

--- a/modules/compiler/src/main/java/script/types/List.java
+++ b/modules/compiler/src/main/java/script/types/List.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.types;
+
+import nextflow.script.dsl.Description;
+
+@Description("""
+    A list is an unordered collection of elements.
+
+    [Read more](https://nextflow.io/docs/latest/reference/stdlib.html#list)
+""")
+@ShimType(java.util.List.class)
+public interface List<E> extends Iterable<E> {
+
+    @Description("""
+        Collates the list into a list of sub-lists of length `size`, stepping through the list `step` elements for each sub-list. If `keepRemainder` is `true`, any remaining elements are included as a partial sub-list, otherwise they are excluded.
+    """)
+    List<?> collate(int size, int step, boolean keepRemainder);
+
+    @Description("""
+        Returns the first element in the list. Raises an error if the list is empty.
+    """)
+    E first();
+
+    @Description("""
+        Returns the list of integers from 0 to *n - 1*, where *n* is the number of elements in the list.
+    """)
+    List<Integer> getIndices();
+
+    @Description("""
+        Returns a list of 2-tuples corresponding to the value and index of each element in the list.
+    """)
+    List withIndex();
+    
+}

--- a/modules/compiler/src/main/java/script/types/Map.java
+++ b/modules/compiler/src/main/java/script/types/Map.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.types;
+
+import java.util.function.BiConsumer;
+
+import nextflow.script.dsl.Description;
+
+@Description("""
+    A map "maps" keys to values. Each key can map to at most one value -- a map cannot contain duplicate keys.
+
+    [Read more](https://nextflow.io/docs/latest/reference/stdlib.html#map)
+""")
+@ShimType(java.util.Map.class)
+public interface Map<K,V> {
+
+    @Description("""
+        Invoke the given closure for each key-value pair in the map. The closure should accept two parameters corresponding to the key and value of an entry.
+    """)
+    void each(BiConsumer<K,V> action);
+
+    @Description("""
+        Returns a set of the key-value pairs in the map.
+    """)
+    Set<Entry<K,V>> entrySet();
+
+    @Description("""
+        A map entry is a key-value pair.
+    """)
+    interface Entry<K,V> {
+        K getKey();
+        V getValue();
+    }
+
+}

--- a/modules/compiler/src/main/java/script/types/Path.java
+++ b/modules/compiler/src/main/java/script/types/Path.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.types;
+
+import nextflow.script.dsl.Constant;
+import nextflow.script.dsl.Description;
+
+@Description("""
+    A Path is a handle for hierarchichal paths such as local files and directories, HTTP/FTP URLs, and object storage paths (e.g. Amazon S3).
+
+    [Read more](https://nextflow.io/docs/latest/reference/stdlib.html#path)
+""")
+@ShimType(java.nio.file.Path.class)
+public interface Path {
+
+    @Constant("text")
+    @Description("""
+        Returns the file content as a string value.
+    """)
+    String getText();
+
+    @Description("""
+        Reads the file line by line and returns the content as a list of strings.
+    """)
+    List<String> readLines();
+
+    @Description("""
+        Splits a CSV file into a list of records.
+    """)
+    List<?> splitCsv();
+
+    @Description("""
+        Splits a text file into a list of lines.
+    """)
+    List<String> splitText();
+
+}

--- a/modules/compiler/src/main/java/script/types/Set.java
+++ b/modules/compiler/src/main/java/script/types/Set.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.types;
+
+import nextflow.script.dsl.Description;
+
+@Description("""
+    A set is an unordered collection that cannot contain duplicate elements.
+
+    [Read more](https://nextflow.io/docs/latest/reference/stdlib.html#set)
+""")
+@ShimType(java.util.Set.class)
+public interface Set<E> extends Iterable<E> {
+}

--- a/modules/compiler/src/main/java/script/types/ShimType.java
+++ b/modules/compiler/src/main/java/script/types/ShimType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.types;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface ShimType {
+    Class value();
+}

--- a/modules/compiler/src/main/java/script/types/String.java
+++ b/modules/compiler/src/main/java/script/types/String.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.types;
+
+import nextflow.script.dsl.Description;
+
+@Description("""
+    A string is an immutable array of characters.
+
+    [Read more](https://nextflow.io/docs/latest/reference/stdlib.html#string)
+""")
+@ShimType(java.lang.String.class)
+public interface String {
+
+    @Description("""
+        Parses the string into an integer.
+    """)
+    Integer toInteger();
+
+    @Description("""
+        Splits the string into a list of substrings using the given delimiters. Each character in the delimiter string is treated as a separate delimiter.
+    """)
+    List<String> tokenize(String delimiters);
+
+}

--- a/modules/compiler/src/main/java/script/types/Types.java
+++ b/modules/compiler/src/main/java/script/types/Types.java
@@ -15,6 +15,7 @@
  */
 package nextflow.script.types;
 
+import java.lang.String;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -29,10 +30,22 @@ public class Types {
         new ClassNode(Path.class)
     );
 
+    // TODO: normalize ClassNode -> String, rename shim types
     public static String normalize(String name) {
-        if( "Object".equals(name) )
-            return "?";
-        return name;
+        return switch (name) {
+            case "Object" -> "?";
+            default -> name;
+        };
+        // if( "BiConsumer<K, V>".equals(name) )
+        //     return "Closure<(K, V)>";
+        // if( "BiFunction<R, E, R>".equals(name) )
+        //     return "Closure<(R, E) -> R>";
+        // if( "Consumer<E>".equals(name) )
+        //     return "Closure<(E)>";
+        // if( "Function<E, R>".equals(name) )
+        //     return "Closure<(E) -> R>";
+        // if( "Predicate<E>".equals(name) )
+        //     return "Closure<(E) -> boolean>";
     }
 
 }

--- a/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptCompletionProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptCompletionProvider.java
@@ -201,7 +201,11 @@ public class ScriptCompletionProvider implements CompletionProvider {
                     break;
             }
 
-            cn = cn.getSuperClass();
+            cn = cn.getSuperClass() != null
+                ? cn.getSuperClass()
+                : cn.getInterfaces().length == 1
+                    ? cn.getInterfaces()[0]
+                    : null;
         }
     }
 
@@ -219,7 +223,11 @@ public class ScriptCompletionProvider implements CompletionProvider {
                     break;
             }
 
-            cn = cn.getSuperClass();
+            cn = cn.getSuperClass() != null
+                ? cn.getSuperClass()
+                : cn.getInterfaces().length == 1
+                    ? cn.getInterfaces()[0]
+                    : null;
         }
     }
 


### PR DESCRIPTION
This seems like the best way to provide auto-completion and hover hints for standard types, and eventually enforce a curated subset of the Java/Groovy standard libraries.

See also: https://github.com/nextflow-io/nextflow/pull/5431