### PR TITLE
Semantic highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The following language features are currently supported:
 - formatting
 - hover hints
 - rename
+- semantic highlighting
 - DAG preview for workflows
 
 ## Requirements

--- a/modules/compiler/src/main/java/config/parser/ConfigAstBuilder.java
+++ b/modules/compiler/src/main/java/config/parser/ConfigAstBuilder.java
@@ -92,6 +92,7 @@ import org.codehaus.groovy.syntax.Types;
 
 import static nextflow.config.parser.ConfigParser.*;
 import static nextflow.script.parser.PositionConfigureUtils.ast;
+import static nextflow.script.parser.PositionConfigureUtils.tokenPosition;
 import static org.codehaus.groovy.ast.expr.VariableExpression.THIS_EXPRESSION;
 import static org.codehaus.groovy.ast.tools.GeneralUtils.*;
 
@@ -1173,6 +1174,7 @@ public class ConfigAstBuilder {
             : null;
         var result = ast( param(type, name, defaultValue), ctx );
         checkInvalidVarName(name, result);
+        result.putNodeMetaData("_START_NAME", tokenPosition(ctx.identifier()));
         return result;
     }
 

--- a/modules/compiler/src/main/java/script/parser/PositionConfigureUtils.java
+++ b/modules/compiler/src/main/java/script/parser/PositionConfigureUtils.java
@@ -136,6 +136,11 @@ public class PositionConfigureUtils {
         return astNode;
     }
 
+    /**
+     * Get the zero-based start position (line, character) of a token.
+     *
+     * @param ctx
+     */
     public static TokenPosition tokenPosition(ParserRuleContext ctx) {
         var token = ctx.getStart();
         return new TokenPosition(

--- a/modules/compiler/src/main/java/script/parser/PositionConfigureUtils.java
+++ b/modules/compiler/src/main/java/script/parser/PositionConfigureUtils.java
@@ -135,4 +135,12 @@ public class PositionConfigureUtils {
 
         return astNode;
     }
+
+    public static TokenPosition tokenPosition(ParserRuleContext ctx) {
+        var token = ctx.getStart();
+        return new TokenPosition(
+            token.getLine() - 1,
+            token.getCharPositionInLine()
+        );
+    }
 }

--- a/modules/compiler/src/main/java/script/parser/ScriptAstBuilder.java
+++ b/modules/compiler/src/main/java/script/parser/ScriptAstBuilder.java
@@ -99,6 +99,7 @@ import org.codehaus.groovy.syntax.SyntaxException;
 import org.codehaus.groovy.syntax.Types;
 
 import static nextflow.script.parser.PositionConfigureUtils.ast;
+import static nextflow.script.parser.PositionConfigureUtils.tokenPosition;
 import static nextflow.script.parser.ScriptParser.*;
 import static nextflow.script.ast.ASTHelpers.*;
 import static org.codehaus.groovy.ast.expr.VariableExpression.THIS_EXPRESSION;
@@ -339,7 +340,11 @@ public class ScriptAstBuilder {
             .map(it -> {
                 var name = it.name.getText();
                 var alias = it.alias != null ? it.alias.getText() : null;
-                return ast( new IncludeVariable(name, alias), it );
+                var result = new IncludeVariable(name, alias);
+                result.putNodeMetaData("_START_NAME", tokenPosition(it.name));
+                if( it.alias != null )
+                    result.putNodeMetaData("_START_ALIAS", tokenPosition(it.alias));
+                return ast( result, it );
             })
             .collect(Collectors.toList());
 
@@ -1525,6 +1530,7 @@ public class ScriptAstBuilder {
             : null;
         var result = ast( param(type, name, defaultValue), ctx );
         checkInvalidVarName(name, result);
+        result.putNodeMetaData("_START_NAME", tokenPosition(ctx.identifier()));
         return result;
     }
 

--- a/modules/compiler/src/main/java/script/parser/TokenPosition.java
+++ b/modules/compiler/src/main/java/script/parser/TokenPosition.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.script.parser;
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public record TokenPosition(
+    int line,           // 0-based
+    int character       // 0-based
+) {}

--- a/modules/language-server/src/main/java/nextflow/lsp/NextflowLanguageServer.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/NextflowLanguageServer.java
@@ -172,7 +172,7 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
         var semanticTokensOptions = new SemanticTokensWithRegistrationOptions(
             new SemanticTokensLegend(
                 SemanticTokensVisitor.TOKEN_TYPES,
-                List.of()
+                Collections.emptyList()
             ),
             true,
             false);

--- a/modules/language-server/src/main/java/nextflow/lsp/NextflowLanguageServer.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/NextflowLanguageServer.java
@@ -31,8 +31,8 @@ import com.google.gson.JsonPrimitive;
 import nextflow.lsp.file.PathUtils;
 import nextflow.lsp.util.Logger;
 import nextflow.lsp.services.LanguageService;
+import nextflow.lsp.services.SemanticTokensVisitor;
 import nextflow.lsp.services.config.ConfigService;
-import nextflow.lsp.services.script.ScriptSemanticTokensProvider;
 import nextflow.lsp.services.script.ScriptService;
 import nextflow.script.formatter.FormattingOptions;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
@@ -171,7 +171,7 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
         serverCapabilities.setReferencesProvider(true);
         var semanticTokensOptions = new SemanticTokensWithRegistrationOptions(
             new SemanticTokensLegend(
-                ScriptSemanticTokensProvider.TOKEN_TYPES,
+                SemanticTokensVisitor.TOKEN_TYPES,
                 List.of()
             ),
             true,

--- a/modules/language-server/src/main/java/nextflow/lsp/services/LanguageService.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/LanguageService.java
@@ -73,6 +73,8 @@ import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.SemanticTokensParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -116,6 +118,7 @@ public abstract class LanguageService {
     protected LinkProvider getLinkProvider() { return null; }
     protected ReferenceProvider getReferenceProvider() { return null; }
     protected RenameProvider getRenameProvider() { return null; }
+    protected SemanticTokensProvider getSemanticTokensProvider() { return null; }
     protected SymbolProvider getSymbolProvider() { return null; }
 
     private volatile boolean initialized;
@@ -293,6 +296,15 @@ public abstract class LanguageService {
             return null;
 
         return provider.rename(params.getTextDocument(), params.getPosition(), params.getNewName());
+    }
+
+    public SemanticTokens semanticTokensFull(SemanticTokensParams params) {
+        var provider = getSemanticTokensProvider();
+        if( provider == null )
+            return null;
+
+        awaitUpdate();
+        return provider.semanticTokensFull(params.getTextDocument());
     }
 
     public List<? extends WorkspaceSymbol> symbol(WorkspaceSymbolParams params) {

--- a/modules/language-server/src/main/java/nextflow/lsp/services/SemanticTokensProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/SemanticTokensProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lsp.services;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+public interface SemanticTokensProvider {
+
+    SemanticTokens semanticTokensFull(TextDocumentIdentifier textDocument);
+
+}

--- a/modules/language-server/src/main/java/nextflow/lsp/services/SemanticTokensVisitor.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/SemanticTokensVisitor.java
@@ -108,7 +108,7 @@ public class SemanticTokensVisitor extends CodeVisitorSupport {
                 0
             ))
             .collect(Collectors.toList());
-            
+
         return new SemanticTokens(data);
     }
 
@@ -186,19 +186,17 @@ public class SemanticTokensVisitor extends CodeVisitorSupport {
         inGString = igs;
     }
 
+    private static record SemanticToken(
+        Position position,
+        int length,
+        String type
+    ) {}
+
+    private static record SemanticTokenDelta(
+        int deltaLine,
+        int deltaStartChar,
+        int length,
+        String type
+    ) {}
+
 }
-
-
-record SemanticToken(
-    Position position,
-    int length,
-    String type
-) {}
-
-
-record SemanticTokenDelta(
-    int deltaLine,
-    int deltaStartChar,
-    int length,
-    String type
-) {}

--- a/modules/language-server/src/main/java/nextflow/lsp/services/SemanticTokensVisitor.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/SemanticTokensVisitor.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lsp.services;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import nextflow.lsp.util.Positions;
+import nextflow.lsp.util.LanguageServerUtils;
+import nextflow.script.parser.TokenPosition;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.CodeVisitorSupport;
+import org.codehaus.groovy.ast.DynamicVariable;
+import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.GStringExpression;
+import org.codehaus.groovy.ast.expr.MapEntryExpression;
+import org.codehaus.groovy.ast.expr.MapExpression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.NamedArgumentListExpression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.SemanticTokenTypes;
+
+import static nextflow.script.ast.ASTHelpers.*;
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public class SemanticTokensVisitor extends CodeVisitorSupport {
+
+    public static final List<String> TOKEN_TYPES = List.of(
+        SemanticTokenTypes.EnumMember,
+        SemanticTokenTypes.Function,
+        SemanticTokenTypes.Number,
+        SemanticTokenTypes.Parameter,
+        SemanticTokenTypes.Property,
+        SemanticTokenTypes.String,
+        SemanticTokenTypes.Type,
+        SemanticTokenTypes.Variable
+    );
+
+    private List<SemanticToken> tokens = new ArrayList<SemanticToken>();
+
+    public void append(ASTNode node, String type) {
+        var length = node.getLastColumnNumber() - node.getColumnNumber();
+        append(node.getLineNumber() - 1, node.getColumnNumber() - 1, length, type);
+    }
+
+    public void append(TokenPosition start, String text, String type) {
+        append(start.line(), start.character(), text.length(), type);
+    }
+
+    public void append(int line, int character, int length, String type) {
+        tokens.add(new SemanticToken(
+            new Position(line, character),
+            length,
+            type
+        ));
+    }
+
+    public SemanticTokens getTokens() {
+        tokens.sort((a, b) -> Positions.COMPARATOR.compare(a.position(), b.position()));
+
+        var deltaTokens = new ArrayList<SemanticTokenDelta>(tokens.size());
+        int line = 0;
+        int startChar = 0;
+        for( var token : tokens ) {
+            var deltaLine = token.position().getLine() - line;
+            var deltaStartChar = deltaLine > 0
+                ? token.position().getCharacter()
+                : token.position().getCharacter() - startChar;
+            deltaTokens.add(new SemanticTokenDelta(
+                deltaLine,
+                deltaStartChar,
+                token.length(),
+                token.type()
+            ));
+            line = token.position().getLine();
+            startChar = token.position().getCharacter();
+        }
+
+        var data = deltaTokens.stream()
+            .flatMap(token -> Stream.of(
+                token.deltaLine(),
+                token.deltaStartChar(),
+                token.length(),
+                TOKEN_TYPES.indexOf(token.type()),
+                0
+            ))
+            .collect(Collectors.toList());
+            
+        return new SemanticTokens(data);
+    }
+
+    // expressions
+
+    @Override
+    public void visitMethodCallExpression(MethodCallExpression node) {
+        if( !node.isImplicitThis() )
+            visit(node.getObjectExpression());
+        append(node.getMethod(), SemanticTokenTypes.Function);
+        visit(node.getArguments());
+    }
+
+    @Override
+    public void visitClosureExpression(ClosureExpression node) {
+        if( node.getParameters() != null )
+            visitParameters(node.getParameters());
+        visit(node.getCode());
+    }
+
+    public void visitParameters(Parameter[] parameters) {
+        for( int i = 0; i < parameters.length; i++ ) {
+            var param = parameters[i];
+            append((TokenPosition) param.getNodeMetaData("_START_NAME"), param.getName(), SemanticTokenTypes.Parameter);
+            if( param.hasInitialExpression() )
+                visit(param.getInitialExpression());
+        }
+    }
+
+    @Override
+    public void visitMapExpression(MapExpression node) {
+        if( node instanceof NamedArgumentListExpression )
+            visitNamedArgs(node.getMapEntryExpressions());
+        else
+            super.visitMapExpression(node);
+    }
+
+    protected void visitNamedArgs(List<MapEntryExpression> args) {
+        for( var namedArg : args ) {
+            append(namedArg.getKeyExpression(), SemanticTokenTypes.Parameter);
+            visit(namedArg.getValueExpression());
+        }
+    }
+
+    @Override
+    public void visitConstantExpression(ConstantExpression node) {
+        if( !inGString )
+            return;
+        var value = node.getValue();
+        if( value instanceof Number )
+            append(node, SemanticTokenTypes.Number);
+        else if( value instanceof String )
+            append(node, SemanticTokenTypes.String);
+    }
+
+    @Override
+    public void visitVariableExpression(VariableExpression node) {
+        if( !(node.getAccessedVariable() instanceof DynamicVariable) )
+            append(node, SemanticTokenTypes.Variable);
+    }
+
+    @Override
+    public void visitPropertyExpression(PropertyExpression node) {
+        visit(node.getObjectExpression());
+        append(node.getProperty(), SemanticTokenTypes.Property);
+    }
+
+    private boolean inGString = false;
+
+    @Override
+    public void visitGStringExpression(GStringExpression node) {
+        var igs = inGString;
+        inGString = true;
+        super.visitGStringExpression(node);
+        inGString = igs;
+    }
+
+}
+
+
+record SemanticToken(
+    Position position,
+    int length,
+    String type
+) {}
+
+
+record SemanticTokenDelta(
+    int deltaLine,
+    int deltaStartChar,
+    int length,
+    String type
+) {}

--- a/modules/language-server/src/main/java/nextflow/lsp/services/config/ConfigSemanticTokensProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/config/ConfigSemanticTokensProvider.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lsp.services.config;
+
+import java.net.URI;
+import java.util.List;
+
+import nextflow.config.ast.ConfigAssignNode;
+import nextflow.config.ast.ConfigIncludeNode;
+import nextflow.config.ast.ConfigNode;
+import nextflow.config.ast.ConfigVisitorSupport;
+import nextflow.lsp.services.SemanticTokensProvider;
+import nextflow.lsp.services.SemanticTokensVisitor;
+import nextflow.lsp.util.Logger;
+import org.codehaus.groovy.control.SourceUnit;
+import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public class ConfigSemanticTokensProvider implements SemanticTokensProvider {
+
+    private static Logger log = Logger.getInstance();
+
+    private ConfigAstCache ast;
+
+    public ConfigSemanticTokensProvider(ConfigAstCache ast) {
+        this.ast = ast;
+    }
+
+    @Override
+    public SemanticTokens semanticTokensFull(TextDocumentIdentifier textDocument) {
+        if( ast == null ) {
+            log.error("ast cache is empty while providing semantic tokens");
+            return null;
+        }
+
+        var uri = URI.create(textDocument.getUri());
+        if( !ast.hasAST(uri) )
+            return null;
+
+        var sourceUnit = ast.getSourceUnit(uri);
+        var visitor = new Visitor(sourceUnit);
+        visitor.visit();
+        return visitor.getTokens();
+    }
+
+    private static class Visitor extends ConfigVisitorSupport {
+    
+        private SourceUnit sourceUnit;
+    
+        private SemanticTokensVisitor tok;
+    
+        public Visitor(SourceUnit sourceUnit) {
+            this.sourceUnit = sourceUnit;
+            this.tok = new SemanticTokensVisitor();
+        }
+    
+        @Override
+        protected SourceUnit getSourceUnit() {
+            return sourceUnit;
+        }
+    
+        public void visit() {
+            var moduleNode = sourceUnit.getAST();
+            if( moduleNode instanceof ConfigNode cn )
+                super.visit(cn);
+        }
+    
+        public SemanticTokens getTokens() {
+            return tok.getTokens();
+        }
+    
+        // config statements
+    
+        @Override
+        public void visitConfigAssign(ConfigAssignNode node) {
+            tok.visit(node.value);
+        }
+    
+        @Override
+        public void visitConfigInclude(ConfigIncludeNode node) {
+            tok.visit(node.source);
+        }
+    
+    }
+
+}

--- a/modules/language-server/src/main/java/nextflow/lsp/services/config/ConfigSemanticTokensProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/config/ConfigSemanticTokensProvider.java
@@ -61,43 +61,43 @@ public class ConfigSemanticTokensProvider implements SemanticTokensProvider {
     }
 
     private static class Visitor extends ConfigVisitorSupport {
-    
+
         private SourceUnit sourceUnit;
-    
+
         private SemanticTokensVisitor tok;
-    
+
         public Visitor(SourceUnit sourceUnit) {
             this.sourceUnit = sourceUnit;
             this.tok = new SemanticTokensVisitor();
         }
-    
+
         @Override
         protected SourceUnit getSourceUnit() {
             return sourceUnit;
         }
-    
+
         public void visit() {
             var moduleNode = sourceUnit.getAST();
             if( moduleNode instanceof ConfigNode cn )
                 super.visit(cn);
         }
-    
+
         public SemanticTokens getTokens() {
             return tok.getTokens();
         }
-    
+
         // config statements
-    
+
         @Override
         public void visitConfigAssign(ConfigAssignNode node) {
             tok.visit(node.value);
         }
-    
+
         @Override
         public void visitConfigInclude(ConfigIncludeNode node) {
             tok.visit(node.source);
         }
-    
+
     }
 
 }

--- a/modules/language-server/src/main/java/nextflow/lsp/services/config/ConfigService.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/config/ConfigService.java
@@ -21,6 +21,7 @@ import nextflow.lsp.services.FormattingProvider;
 import nextflow.lsp.services.HoverProvider;
 import nextflow.lsp.services.LanguageService;
 import nextflow.lsp.services.LinkProvider;
+import nextflow.lsp.services.SemanticTokensProvider;
 
 /**
  * Implementation of language services for Nextflow config files.
@@ -59,6 +60,11 @@ public class ConfigService extends LanguageService {
     @Override
     protected LinkProvider getLinkProvider() {
         return new ConfigLinkProvider(astCache);
+    }
+
+    @Override
+    protected SemanticTokensProvider getSemanticTokensProvider() {
+        return new ConfigSemanticTokensProvider(astCache);
     }
 
 }

--- a/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptHoverProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptHoverProvider.java
@@ -103,6 +103,12 @@ public class ScriptHoverProvider implements HoverProvider {
                 }
                 builder.append('\n');
             }
+            var tokenType = ScriptSemanticTokensProvider.getTokenType(offsetNode, ast);
+            if( tokenType != null ) {
+                builder.append("semantic token: ");
+                builder.append(tokenType);
+                builder.append('\n');
+            }
             builder.append("\n```");
         }
 

--- a/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptHoverProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptHoverProvider.java
@@ -103,12 +103,6 @@ public class ScriptHoverProvider implements HoverProvider {
                 }
                 builder.append('\n');
             }
-            var tokenType = ScriptSemanticTokensProvider.getTokenType(offsetNode, ast);
-            if( tokenType != null ) {
-                builder.append("semantic token: ");
-                builder.append(tokenType);
-                builder.append('\n');
-            }
             builder.append("\n```");
         }
 

--- a/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptSemanticTokensProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptSemanticTokensProvider.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2024, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lsp.services.script;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import nextflow.lsp.ast.ASTUtils;
+import nextflow.lsp.services.SemanticTokensProvider;
+import nextflow.lsp.util.Logger;
+import nextflow.lsp.util.Positions;
+import nextflow.lsp.util.LanguageServerUtils;
+import nextflow.script.ast.IncludeVariable;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.ast.Variable;
+import org.codehaus.groovy.ast.expr.ClassExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+public class ScriptSemanticTokensProvider implements SemanticTokensProvider {
+
+    public static final List<String> TOKEN_TYPES = List.of(
+        SemanticTokenTypes.Type,
+        SemanticTokenTypes.Function,
+        SemanticTokenTypes.Parameter,
+        SemanticTokenTypes.Variable
+    );
+
+    private static Logger log = Logger.getInstance();
+
+    private ScriptAstCache ast;
+
+    public ScriptSemanticTokensProvider(ScriptAstCache ast) {
+        this.ast = ast;
+    }
+
+    @Override
+    public SemanticTokens semanticTokensFull(TextDocumentIdentifier textDocument) {
+        if( ast == null ) {
+            log.error("ast cache is empty while providing semantic tokens");
+            return null;
+        }
+
+        var uri = URI.create(textDocument.getUri());
+        if( !ast.hasAST(uri) )
+            return null;
+
+        var tokens = ast.getNodes(uri).stream()
+            .map(node -> getSemanticToken(node))
+            .filter(token -> token != null)
+            .sorted((a, b) -> Positions.COMPARATOR.compare(a.position(), b.position()))
+            .collect(Collectors.toList());
+
+        var deltaTokens = new ArrayList<SemanticTokenDelta>(tokens.size());
+        int line = 0;
+        int startChar = 0;
+        for( var token : tokens ) {
+            var deltaLine = token.position().getLine() - line;
+            var deltaStartChar = deltaLine > 0
+                ? token.position().getCharacter()
+                : token.position().getCharacter() - startChar;
+            deltaTokens.add(new SemanticTokenDelta(
+                deltaLine,
+                deltaStartChar,
+                token.length(),
+                token.type(),
+                token.modifiers()
+            ));
+            line = token.position().getLine();
+            startChar = token.position().getCharacter();
+        }
+
+        var data = deltaTokens.stream()
+            .flatMap(token -> Stream.of(
+                token.deltaLine(),
+                token.deltaStartChar(),
+                token.length(),
+                TOKEN_TYPES.indexOf(token.type()),
+                0
+            ))
+            .collect(Collectors.toList());
+            
+        return new SemanticTokens(data);
+    }
+
+    private SemanticToken getSemanticToken(ASTNode node) {
+        if( node.getLineNumber() != node.getLastLineNumber() )
+            return null;
+        var position = LanguageServerUtils.groovyToLspPosition(node.getLineNumber(), node.getColumnNumber());
+        if( position == null )
+            return null;
+        var length = node.getLastColumnNumber() - node.getColumnNumber();
+        var type = getTokenType(node, ast);
+        if( type == null )
+            return null;
+        return new SemanticToken(
+            position,
+            length,
+            type,
+            getTokenModifiers(node)
+        );
+    }
+
+    static String getTokenType(ASTNode node, ScriptAstCache ast) {
+        if( node instanceof ClassNode )
+            return SemanticTokenTypes.Type;
+
+        if( node instanceof IncludeVariable )
+            return null;
+
+        if( node instanceof MethodNode )
+            return SemanticTokenTypes.Function;
+
+        if( node instanceof Parameter )
+            return SemanticTokenTypes.Parameter;
+
+        if( node instanceof Variable )
+            return SemanticTokenTypes.Variable;
+
+        if( node instanceof ClassExpression || node instanceof ConstantExpression )
+            return getTokenType(ASTUtils.getDefinition(node, ast), ast);
+
+        return null;
+    }
+
+    static List<String> getTokenModifiers(ASTNode node) {
+        return Collections.emptyList();
+    }
+}
+
+record SemanticToken(
+    Position position,
+    int length,
+    String type,
+    List<String> modifiers
+) {}
+
+record SemanticTokenDelta(
+    int deltaLine,
+    int deltaStartChar,
+    int length,
+    String type,
+    List<String> modifiers
+) {}

--- a/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptSemanticTokensProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptSemanticTokensProvider.java
@@ -27,18 +27,37 @@ import nextflow.lsp.services.SemanticTokensProvider;
 import nextflow.lsp.util.Logger;
 import nextflow.lsp.util.Positions;
 import nextflow.lsp.util.LanguageServerUtils;
-import nextflow.script.ast.IncludeVariable;
+import nextflow.script.ast.AssignmentExpression;
+import nextflow.script.ast.FunctionNode;
+import nextflow.script.ast.IncludeNode;
+import nextflow.script.ast.OutputNode;
+import nextflow.script.ast.ProcessNode;
+import nextflow.script.ast.ScriptNode;
+import nextflow.script.ast.ScriptVisitorSupport;
+import nextflow.script.ast.WorkflowNode;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassNode;
-import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.DynamicVariable;
 import org.codehaus.groovy.ast.Parameter;
-import org.codehaus.groovy.ast.Variable;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
 import org.codehaus.groovy.ast.expr.ClassExpression;
-import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.MapEntryExpression;
+import org.codehaus.groovy.ast.expr.MapExpression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.NamedArgumentListExpression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.ExpressionStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
+import org.codehaus.groovy.control.SourceUnit;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.SemanticTokens;
 import org.eclipse.lsp4j.SemanticTokenTypes;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+import static nextflow.script.ast.ASTHelpers.*;
 
 /**
  *
@@ -47,9 +66,11 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 public class ScriptSemanticTokensProvider implements SemanticTokensProvider {
 
     public static final List<String> TOKEN_TYPES = List.of(
-        SemanticTokenTypes.Type,
+        SemanticTokenTypes.EnumMember,
         SemanticTokenTypes.Function,
         SemanticTokenTypes.Parameter,
+        SemanticTokenTypes.Property,
+        SemanticTokenTypes.Type,
         SemanticTokenTypes.Variable
     );
 
@@ -72,11 +93,12 @@ public class ScriptSemanticTokensProvider implements SemanticTokensProvider {
         if( !ast.hasAST(uri) )
             return null;
 
-        var tokens = ast.getNodes(uri).stream()
-            .map(node -> getSemanticToken(node))
-            .filter(token -> token != null)
-            .sorted((a, b) -> Positions.COMPARATOR.compare(a.position(), b.position()))
-            .collect(Collectors.toList());
+        var sourceUnit = ast.getSourceUnit(uri);
+        var visitor = new ScriptSemanticTokensVisitor(sourceUnit, ast);
+        visitor.visit();
+
+        var tokens = visitor.getTokens();
+        tokens.sort((a, b) -> Positions.COMPARATOR.compare(a.position(), b.position()));
 
         var deltaTokens = new ArrayList<SemanticTokenDelta>(tokens.size());
         int line = 0;
@@ -90,8 +112,7 @@ public class ScriptSemanticTokensProvider implements SemanticTokensProvider {
                 deltaLine,
                 deltaStartChar,
                 token.length(),
-                token.type(),
-                token.modifiers()
+                token.type()
             ));
             line = token.position().getLine();
             startChar = token.position().getCharacter();
@@ -110,62 +131,224 @@ public class ScriptSemanticTokensProvider implements SemanticTokensProvider {
         return new SemanticTokens(data);
     }
 
-    private SemanticToken getSemanticToken(ASTNode node) {
-        if( node.getLineNumber() != node.getLastLineNumber() )
-            return null;
-        var position = LanguageServerUtils.groovyToLspPosition(node.getLineNumber(), node.getColumnNumber());
-        if( position == null )
-            return null;
-        var length = node.getLastColumnNumber() - node.getColumnNumber();
-        var type = getTokenType(node, ast);
-        if( type == null )
-            return null;
-        return new SemanticToken(
-            position,
-            length,
-            type,
-            getTokenModifiers(node)
-        );
-    }
-
-    static String getTokenType(ASTNode node, ScriptAstCache ast) {
-        if( node instanceof ClassNode )
-            return SemanticTokenTypes.Type;
-
-        if( node instanceof IncludeVariable )
-            return null;
-
-        if( node instanceof MethodNode )
-            return SemanticTokenTypes.Function;
-
-        if( node instanceof Parameter )
-            return SemanticTokenTypes.Parameter;
-
-        if( node instanceof Variable )
-            return SemanticTokenTypes.Variable;
-
-        if( node instanceof ClassExpression || node instanceof ConstantExpression )
-            return getTokenType(ASTUtils.getDefinition(node, ast), ast);
-
-        return null;
-    }
-
-    static List<String> getTokenModifiers(ASTNode node) {
-        return Collections.emptyList();
-    }
 }
+
 
 record SemanticToken(
     Position position,
     int length,
-    String type,
-    List<String> modifiers
+    String type
 ) {}
+
 
 record SemanticTokenDelta(
     int deltaLine,
     int deltaStartChar,
     int length,
-    String type,
-    List<String> modifiers
+    String type
 ) {}
+
+
+class ScriptSemanticTokensVisitor extends ScriptVisitorSupport {
+
+    private SourceUnit sourceUnit;
+
+    private ScriptAstCache ast;
+
+    private List<SemanticToken> tokens = new ArrayList<SemanticToken>();
+
+    public ScriptSemanticTokensVisitor(SourceUnit sourceUnit, ScriptAstCache ast) {
+        this.sourceUnit = sourceUnit;
+        this.ast = ast;
+    }
+
+    @Override
+    protected SourceUnit getSourceUnit() {
+        return sourceUnit;
+    }
+
+    public void visit() {
+        var moduleNode = sourceUnit.getAST();
+        if( moduleNode instanceof ScriptNode sn )
+            visit(sn);
+    }
+
+    protected void addToken(ASTNode node, String type) {
+        var position = LanguageServerUtils.groovyToLspPosition(node.getLineNumber(), node.getColumnNumber());
+        var length = node.getLastColumnNumber() - node.getColumnNumber();
+        tokens.add(new SemanticToken(
+            position,
+            length,
+            type
+        ));
+    }
+
+    public List<SemanticToken> getTokens() {
+        return tokens;
+    }
+
+    // script declarations
+
+    // TODO: highlight include name and alias as definitions?
+    // @Override
+    // public void visitInclude(IncludeNode node) {
+    // }
+
+    @Override
+    public void visitWorkflow(WorkflowNode node) {
+        if( node.takes instanceof BlockStatement block )
+            visitWorkflowTakes(block.getStatements());
+
+        visit(node.main);
+
+        if( node.emits instanceof BlockStatement block )
+            visitWorkflowEmits(block.getStatements());
+
+        visit(node.publishers);
+    }
+
+    protected void visitWorkflowTakes(List<Statement> takes) {
+        for( var stmt : takes ) {
+            var ve = (VariableExpression) asVarX(stmt);
+            addToken(ve, SemanticTokenTypes.Parameter);
+        }
+    }
+
+    protected void visitWorkflowEmits(List<Statement> emits) {
+        for( var stmt : emits ) {
+            var es = (ExpressionStatement)stmt;
+            var emit = es.getExpression();
+            if( emit instanceof AssignmentExpression assign ) {
+                var ve = (VariableExpression)assign.getLeftExpression();
+                addToken(ve, SemanticTokenTypes.Parameter);
+                visit(assign.getRightExpression());
+            }
+            else if( emit instanceof VariableExpression ve ) {
+                if( emits.size() == 1 )
+                    visit(emit);
+                else
+                    addToken(ve, SemanticTokenTypes.Parameter);
+            }
+            else {
+                visit(stmt);
+            }
+        }
+    }
+
+    @Override
+    public void visitProcess(ProcessNode node) {
+        visit(node.directives);
+        visit(node.inputs);
+        visit(node.outputs);
+        visit(node.when);
+        // TODO: highlight embedded scripts
+        visit(node.exec);
+        visit(node.stub);
+    }
+
+    @Override
+    public void visitFunction(FunctionNode node) {
+        visitParameters(node.getParameters());
+        visit(node.getCode());
+    }
+
+    public void visitParameters(Parameter[] parameters) {
+        for( int i = 0; i < parameters.length; i++ ) {
+            var param = parameters[i];
+            // TODO: highlight param name
+            // addToken(param.getName(), SemanticTokenTypes.Parameter);
+            visitTypeName(param.getType());
+            if( param.hasInitialExpression() )
+                visit(param.getInitialExpression());
+        }
+    }
+
+    @Override
+    public void visitEnum(ClassNode node) {
+        for( var fn : node.getFields() )
+            addToken(fn, SemanticTokenTypes.EnumMember);
+    }
+
+    @Override
+    public void visitOutput(OutputNode node) {
+        visitOutputBody(node.body);
+    }
+
+    protected void visitOutputBody(Statement body) {
+        asBlockStatements(body).forEach((stmt) -> {
+            var call = asMethodCallX(stmt);
+            if( call == null )
+                return;
+
+            var code = asDslBlock(call, 1);
+            if( code != null ) {
+                addToken(call.getMethod(), SemanticTokenTypes.Parameter);
+                visit(code);
+            }
+        });
+    }
+
+    // expressions
+
+    @Override
+    public void visitMethodCallExpression(MethodCallExpression node) {
+        if( !node.isImplicitThis() )
+            visit(node.getObjectExpression());
+        addToken(node.getMethod(), SemanticTokenTypes.Function);
+        visit(node.getArguments());
+    }
+
+    @Override
+    public void visitBinaryExpression(BinaryExpression node) {
+        visit(node.getLeftExpression());
+
+        // TODO: fix division + comment parsed as regex
+        // addToken(node.getOperation(), SemanticTokenTypes.Operator);
+
+        visit(node.getRightExpression());
+    }
+
+    @Override
+    public void visitClosureExpression(ClosureExpression node) {
+        if( node.getParameters() != null )
+            visitParameters(node.getParameters());
+        visit(node.getCode());
+    }
+
+    @Override
+    public void visitMapExpression(MapExpression node) {
+        if( node instanceof NamedArgumentListExpression )
+            visitNamedArgs(node.getMapEntryExpressions());
+        else
+            super.visitMapExpression(node);
+    }
+
+    protected void visitNamedArgs(List<MapEntryExpression> args) {
+        for( var namedArg : args ) {
+            addToken(namedArg.getKeyExpression(), SemanticTokenTypes.Parameter);
+            visit(namedArg.getValueExpression());
+        }
+    }
+
+    @Override
+    public void visitClassExpression(ClassExpression node) {
+        visitTypeName(node.getType());
+    }
+
+    protected void visitTypeName(ClassNode type) {
+        // addToken(type, SemanticTokenTypes.Type);
+    }
+
+    @Override
+    public void visitVariableExpression(VariableExpression node) {
+        if( !(node.getAccessedVariable() instanceof DynamicVariable) )
+            addToken(node, SemanticTokenTypes.Variable);
+    }
+
+    @Override
+    public void visitPropertyExpression(PropertyExpression node) {
+        visit(node.getObjectExpression());
+        addToken(node.getProperty(), SemanticTokenTypes.Property);
+    }
+
+}

--- a/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptSemanticTokensProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptSemanticTokensProvider.java
@@ -31,7 +31,6 @@ import nextflow.script.ast.AssignmentExpression;
 import nextflow.script.ast.FunctionNode;
 import nextflow.script.ast.IncludeNode;
 import nextflow.script.ast.OutputNode;
-import nextflow.script.ast.ProcessNode;
 import nextflow.script.ast.ScriptNode;
 import nextflow.script.ast.ScriptVisitorSupport;
 import nextflow.script.ast.WorkflowNode;
@@ -40,8 +39,6 @@ import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.DynamicVariable;
 import org.codehaus.groovy.ast.Parameter;
-import org.codehaus.groovy.ast.expr.BinaryExpression;
-import org.codehaus.groovy.ast.expr.ClassExpression;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.MapEntryExpression;
 import org.codehaus.groovy.ast.expr.MapExpression;
@@ -251,17 +248,6 @@ class ScriptSemanticTokensVisitor extends ScriptVisitorSupport {
     }
 
     @Override
-    public void visitProcess(ProcessNode node) {
-        visit(node.directives);
-        visit(node.inputs);
-        visit(node.outputs);
-        visit(node.when);
-        // TODO: highlight embedded scripts
-        visit(node.exec);
-        visit(node.stub);
-    }
-
-    @Override
     public void visitFunction(FunctionNode node) {
         visitParameters(node.getParameters());
         visit(node.getCode());
@@ -271,7 +257,6 @@ class ScriptSemanticTokensVisitor extends ScriptVisitorSupport {
         for( int i = 0; i < parameters.length; i++ ) {
             var param = parameters[i];
             addToken(param.getNodeMetaData("_START_NAME"), param.getName(), SemanticTokenTypes.Parameter);
-            visitTypeName(param.getType());
             if( param.hasInitialExpression() )
                 visit(param.getInitialExpression());
         }
@@ -313,16 +298,6 @@ class ScriptSemanticTokensVisitor extends ScriptVisitorSupport {
     }
 
     @Override
-    public void visitBinaryExpression(BinaryExpression node) {
-        visit(node.getLeftExpression());
-
-        // TODO: fix division + comment parsed as regex
-        // addToken(node.getOperation(), SemanticTokenTypes.Operator);
-
-        visit(node.getRightExpression());
-    }
-
-    @Override
     public void visitClosureExpression(ClosureExpression node) {
         if( node.getParameters() != null )
             visitParameters(node.getParameters());
@@ -342,15 +317,6 @@ class ScriptSemanticTokensVisitor extends ScriptVisitorSupport {
             addToken(namedArg.getKeyExpression(), SemanticTokenTypes.Parameter);
             visit(namedArg.getValueExpression());
         }
-    }
-
-    @Override
-    public void visitClassExpression(ClassExpression node) {
-        visitTypeName(node.getType());
-    }
-
-    protected void visitTypeName(ClassNode type) {
-        // addToken(type, SemanticTokenTypes.Type);
     }
 
     @Override

--- a/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptSemanticTokensProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptSemanticTokensProvider.java
@@ -75,36 +75,36 @@ public class ScriptSemanticTokensProvider implements SemanticTokensProvider {
     }
 
     private static class Visitor extends ScriptVisitorSupport {
-    
+
         private SourceUnit sourceUnit;
-    
+
         private SemanticTokensVisitor tok;
-    
+
         public Visitor(SourceUnit sourceUnit) {
             this.sourceUnit = sourceUnit;
             this.tok = new SemanticTokensVisitor();
         }
-    
+
         @Override
         protected SourceUnit getSourceUnit() {
             return sourceUnit;
         }
-    
+
         public void visit() {
             var moduleNode = sourceUnit.getAST();
             if( moduleNode instanceof ScriptNode sn )
                 visit(sn);
         }
-    
+
         public SemanticTokens getTokens() {
             return tok.getTokens();
         }
-    
+
         @Override
         public void visitFeatureFlag(FeatureFlagNode node) {
             tok.visit(node.value);
         }
-    
+
         @Override
         public void visitInclude(IncludeNode node) {
             for( var module : node.modules ) {
@@ -113,33 +113,33 @@ public class ScriptSemanticTokensProvider implements SemanticTokensProvider {
                     tok.append(module.getNodeMetaData("_START_ALIAS"), module.alias, SemanticTokenTypes.Function);
             }
         }
-    
+
         @Override
         public void visitParam(ParamNode node) {
             tok.visit(node.target);
             tok.visit(node.value);
         }
-    
+
         @Override
         public void visitWorkflow(WorkflowNode node) {
             if( node.takes instanceof BlockStatement block )
                 visitWorkflowTakes(block.getStatements());
-    
+
             tok.visit(node.main);
-    
+
             if( node.emits instanceof BlockStatement block )
                 visitWorkflowEmits(block.getStatements());
-    
+
             tok.visit(node.publishers);
         }
-    
+
         protected void visitWorkflowTakes(List<Statement> takes) {
             for( var stmt : takes ) {
                 var ve = (VariableExpression) asVarX(stmt);
                 tok.append(ve, SemanticTokenTypes.Parameter);
             }
         }
-    
+
         protected void visitWorkflowEmits(List<Statement> emits) {
             for( var stmt : emits ) {
                 var es = (ExpressionStatement)stmt;
@@ -160,7 +160,7 @@ public class ScriptSemanticTokensProvider implements SemanticTokensProvider {
                 }
             }
         }
-    
+
         @Override
         public void visitProcess(ProcessNode node) {
             tok.visit(node.directives);
@@ -170,30 +170,30 @@ public class ScriptSemanticTokensProvider implements SemanticTokensProvider {
             tok.visit(node.exec);
             tok.visit(node.stub);
         }
-    
+
         @Override
         public void visitFunction(FunctionNode node) {
             tok.visitParameters(node.getParameters());
             tok.visit(node.getCode());
         }
-    
+
         @Override
         public void visitEnum(ClassNode node) {
             for( var fn : node.getFields() )
                 tok.append(fn, SemanticTokenTypes.EnumMember);
         }
-    
+
         @Override
         public void visitOutput(OutputNode node) {
             visitOutputBody(node.body);
         }
-    
+
         protected void visitOutputBody(Statement body) {
             asBlockStatements(body).forEach((stmt) -> {
                 var call = asMethodCallX(stmt);
                 if( call == null )
                     return;
-    
+
                 var code = asDslBlock(call, 1);
                 if( code != null ) {
                     tok.append(call.getMethod(), SemanticTokenTypes.Parameter);
@@ -201,7 +201,7 @@ public class ScriptSemanticTokensProvider implements SemanticTokensProvider {
                 }
             });
         }
-    
+
     }
 
 }

--- a/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptSemanticTokensProvider.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptSemanticTokensProvider.java
@@ -31,6 +31,7 @@ import nextflow.script.ast.AssignmentExpression;
 import nextflow.script.ast.FunctionNode;
 import nextflow.script.ast.IncludeNode;
 import nextflow.script.ast.OutputNode;
+import nextflow.script.ast.ParamNode;
 import nextflow.script.ast.ScriptNode;
 import nextflow.script.ast.ScriptVisitorSupport;
 import nextflow.script.ast.WorkflowNode;
@@ -204,6 +205,12 @@ class ScriptSemanticTokensVisitor extends ScriptVisitorSupport {
             if( module.alias != null )
                 addToken(module.getNodeMetaData("_START_ALIAS"), module.alias, SemanticTokenTypes.Function);
         }
+    }
+
+    @Override
+    public void visitParam(ParamNode node) {
+        visit(node.target);
+        visit(node.value);
     }
 
     @Override

--- a/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptService.java
+++ b/modules/language-server/src/main/java/nextflow/lsp/services/script/ScriptService.java
@@ -29,6 +29,7 @@ import nextflow.lsp.services.LanguageService;
 import nextflow.lsp.services.LinkProvider;
 import nextflow.lsp.services.ReferenceProvider;
 import nextflow.lsp.services.RenameProvider;
+import nextflow.lsp.services.SemanticTokensProvider;
 import nextflow.lsp.services.SymbolProvider;
 
 /**
@@ -101,6 +102,11 @@ public class ScriptService extends LanguageService {
     @Override
     protected RenameProvider getRenameProvider() {
         return new ScriptReferenceProvider(astCache);
+    }
+
+    @Override
+    protected SemanticTokensProvider getSemanticTokensProvider() {
+        return new ScriptSemanticTokensProvider(astCache);
     }
 
     @Override


### PR DESCRIPTION
Close #8 

Semantic tokens are used on top of the syntax highlighting, so the language server need only override tokens which aren't accurately described by the TextMate grammar.

The encoding of semantic tokens is described [here](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens)

The first pass just tries to provide semantic token types for named symbols like variable/function names. Some things to improve:
- support the semanticTokens/range LSP request (?)
- support semantic token deltas on individual text edits (?)
- add configuration option (is this needed on top of editor option?)
- preserve CST token ranges in AST (e.g. parameter names)