### PR TITLE
Add lib directory to classpath

### DIFF
--- a/modules/compiler/src/main/java/script/control/ResolveVisitor.java
+++ b/modules/compiler/src/main/java/script/control/ResolveVisitor.java
@@ -68,13 +68,10 @@ public class ResolveVisitor extends ScriptExpressionTransformer {
 
     private List<ClassNode> defaultImports;
 
-    private List<ClassNode> libImports;
-
-    public ResolveVisitor(SourceUnit sourceUnit, CompilationUnit compilationUnit, List<ClassNode> defaultImports, List<ClassNode> libImports) {
+    public ResolveVisitor(SourceUnit sourceUnit, CompilationUnit compilationUnit, List<ClassNode> defaultImports) {
         this.sourceUnit = sourceUnit;
         this.compilationUnit = compilationUnit;
         this.defaultImports = defaultImports;
-        this.libImports = libImports;
     }
 
     @Override
@@ -142,8 +139,6 @@ public class ResolveVisitor extends ScriptExpressionTransformer {
             return true;
         if( resolveFromModule(type) )
             return true;
-        if( resolveFromLibImports(type) )
-            return true;
         if( !type.hasPackageName() && resolveFromDefaultImports(type) )
             return true;
         return resolveFromClassResolver(type.getName()) != null;
@@ -177,17 +172,6 @@ public class ResolveVisitor extends ScriptExpressionTransformer {
             if( name.equals(cn.getName()) ) {
                 if( cn != type )
                     type.setRedirect(cn);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    protected boolean resolveFromLibImports(ClassNode type) {
-        var name = type.getName();
-        for( var cn : libImports ) {
-            if( name.equals(cn.getName()) ) {
-                type.setRedirect(cn);
                 return true;
             }
         }


### PR DESCRIPTION
Simplify lib directory support by using the same approach as Nextflow -- add the `lib` directory (and any JARs in it) to the compiler classpath. `GroovyLibCache` is removed; nf-lang's `ResolveVisitor` already compiles Groovy sources found on the classpath on demand, so the language server doesn't need to compile the lib directory itself.

Rebased on the current `main` (the original commit predates the compiler module moving to nf-lang).

### The hang

The original attempt hung with no error output. The cause was `ResolveVisitor.resolveFromClassResolver`, which threw `GroovyBugError` when the class resolver returned a `SourceUnit` instead of a `ClassNode` -- exactly what happens when a `.groovy` file is found on the classpath. `LanguageService.update()` had no try/catch at the time, so the error propagated into the debounce executor, where a scheduled task's exception is captured in an unread `Future` and silently dropped. The update thread died on the first reference to a lib class, diagnostics were never published, and nothing was logged.

Both halves are fixed upstream: nf-lang now compiles the source unit via `GroovyCompiler`, and `update0()` catches `Throwable`.

### Two rough edges handled here

- `GroovyCompiler.compile()` lets `CompilationFailedException` escape, so a lib class with a syntax error -- normal while editing -- aborted the whole analysis pass and left the script with *no* diagnostics. Name resolution is now guarded per file. Arguably better fixed in nf-lang.
- `GroovyClassLoader` fixes its classpath at construction, so a lib directory created after startup was never seen. Groovy sources are now resolved against the lib directory on each lookup via a `GroovyResourceLoader`. New JARs still require a restart.

`ScriptLibDirTest` covers resolution by simple and fully-qualified name, type annotations, live edits to lib classes, a lib class with a syntax error, a missing lib directory, and no workspace root.