### PR TITLE
Add option for lightweight startup

### DIFF
--- a/src/main/java/nextflow/lsp/NextflowLanguageServer.java
+++ b/src/main/java/nextflow/lsp/NextflowLanguageServer.java
@@ -452,6 +452,7 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
             withDefault(JsonUtils.getBoolean(settings, "nextflow.formatting.harshilAlignment"), configuration.harshilAlignment()),
             withDefault(JsonUtils.getBoolean(settings, "nextflow.formatting.maheshForm"), configuration.maheshForm()),
             withDefault(JsonUtils.getInteger(settings, "nextflow.completion.maxItems"), configuration.maxCompletionItems()),
+            withDefault(JsonUtils.getBoolean(settings, "nextflow.files.scanWorkspace"), configuration.scanWorkspace()),
             withDefault(JsonUtils.getBoolean(settings, "nextflow.formatting.sortDeclarations"), configuration.sortDeclarations()),
             withDefault(JsonUtils.getBoolean(settings, "nextflow.typeChecking"), configuration.typeChecking())
         );

--- a/src/main/java/nextflow/lsp/ast/ASTNodeCache.java
+++ b/src/main/java/nextflow/lsp/ast/ASTNodeCache.java
@@ -102,7 +102,7 @@ public abstract class ASTNodeCache {
 
         // parse source files
         var sources = uris.parallelStream()
-            .map(uri -> compiler.getSource(uri, fileCache))
+            .map(uri -> compiler.newSourceUnit(uri, fileCache))
             .filter(sourceUnit -> sourceUnit != null)
             .map(sourceUnit -> {
                 compiler.addSource(sourceUnit);
@@ -113,7 +113,7 @@ public abstract class ASTNodeCache {
             .collect(Collectors.toSet());
 
         // perform additional ast analysis
-        var changedUris = analyze(uris);
+        var changedUris = analyze(uris, fileCache);
 
         // update ast parents cache
         for( var sourceUnit : sources ) {
@@ -164,8 +164,9 @@ public abstract class ASTNodeCache {
      * Return the set of files whose errors have changed.
      *
      * @param uris
+     * @param fileCache
      */
-    protected abstract Set<URI> analyze(Set<URI> uris);
+    protected abstract Set<URI> analyze(Set<URI> uris, FileCache fileCache);
 
     /**
      * Visit the AST of a source file and retrieve the set of relevant

--- a/src/main/java/nextflow/lsp/compiler/LanguageServerCompiler.java
+++ b/src/main/java/nextflow/lsp/compiler/LanguageServerCompiler.java
@@ -50,7 +50,7 @@ public class LanguageServerCompiler extends Compiler {
      *
      * @param uri
      */
-    public SourceUnit getSource(URI uri, FileCache fileCache) {
+    public SourceUnit newSourceUnit(URI uri, FileCache fileCache) {
         if( fileCache.isOpen(uri) ) {
             var contents = fileCache.getContents(uri);
             return new SourceUnit(
@@ -60,18 +60,14 @@ public class LanguageServerCompiler extends Compiler {
                     classLoader(),
                     newErrorCollector());
         }
-        else if( Files.exists(Path.of(uri)) ) {
-            return new SourceUnit(
-                    new File(uri),
-                    configuration(),
-                    classLoader(),
-                    newErrorCollector());
+        if( Files.exists(Path.of(uri)) ) {
+            return super.newSourceUnit(new File(uri));
         }
-        else
-            return null;
+        return null;
     }
 
-    private ErrorCollector newErrorCollector() {
+    @Override
+    protected ErrorCollector newErrorCollector() {
         return new LanguageServerErrorCollector(configuration());
     }
 

--- a/src/main/java/nextflow/lsp/services/LanguageServerConfiguration.java
+++ b/src/main/java/nextflow/lsp/services/LanguageServerConfiguration.java
@@ -25,6 +25,7 @@ public record LanguageServerConfiguration(
     boolean harshilAlignment,
     boolean maheshForm,
     int maxCompletionItems,
+    boolean scanWorkspace,
     boolean sortDeclarations,
     boolean typeChecking
 ) {
@@ -37,6 +38,7 @@ public record LanguageServerConfiguration(
             false,
             false,
             100,
+            false,
             false,
             false
         );

--- a/src/main/java/nextflow/lsp/services/LanguageService.java
+++ b/src/main/java/nextflow/lsp/services/LanguageService.java
@@ -128,20 +128,27 @@ public abstract class LanguageService {
             this.initialized = false;
             this.configuration = configuration;
 
-            var uris = rootUri != null
-                ? getWorkspaceFiles(rootUri)
-                : fileCache.getOpenFiles();
-
             var astCache = getAstCache();
-            astCache.clear();
-            var changedUris = astCache.update(uris, fileCache);
-            publishDiagnostics(changedUris);
+
+            if( configuration.scanWorkspace() ) {
+                var uris = getWorkspaceFiles(rootUri);
+                astCache.clear();
+                var changedUris = astCache.update(uris, fileCache);
+                publishDiagnostics(changedUris);
+            }
+            else {
+                clearDiagnostics();
+                astCache.clear();
+            }
 
             this.initialized = true;
         }
     }
 
     protected Set<URI> getWorkspaceFiles(String rootUri) {
+        if( rootUri == null ) {
+            return fileCache.getOpenFiles();
+        }
         try {
             var result = new HashSet<URI>();
             PathUtils.visitFiles(

--- a/src/main/java/nextflow/lsp/services/config/ConfigAstCache.java
+++ b/src/main/java/nextflow/lsp/services/config/ConfigAstCache.java
@@ -27,6 +27,7 @@ import nextflow.config.parser.ConfigParserPluginFactory;
 import nextflow.lsp.ast.ASTNodeCache;
 import nextflow.lsp.compiler.LanguageServerCompiler;
 import nextflow.lsp.compiler.LanguageServerErrorCollector;
+import nextflow.lsp.file.FileCache;
 import nextflow.lsp.services.LanguageServerConfiguration;
 import nextflow.script.control.PhaseAware;
 import nextflow.script.control.Phases;
@@ -65,7 +66,7 @@ public class ConfigAstCache extends ASTNodeCache {
     }
 
     @Override
-    protected Set<URI> analyze(Set<URI> uris) {
+    protected Set<URI> analyze(Set<URI> uris, FileCache fileCache) {
         // phase 2: include checking
         var changedUris = new HashSet<>(uris);
 


### PR DESCRIPTION
Close #107 

- Add `nextflow.files.scanWorkspace` option which controls whether to scan the workspace for scripts/configs on startup (disabled by default)
- When the workspace scan is disabled, parse scripts and configs only when they are opened
- In the case of scripts, included modules are recursively parsed as well to facilitate error checking