### PR TITLE
Fix StringIndexOutOfBoundsException in FileCache.didChange() for piecemeal didChange events (#112)

### DIFF
--- a/src/main/java/nextflow/lsp/file/FileCache.java
+++ b/src/main/java/nextflow/lsp/file/FileCache.java
@@ -96,11 +96,11 @@ public class FileCache {
                 var range = change.getRange();
                 var offsetStart = Positions.getOffset(oldText, range.getStart());
                 var offsetEnd = Positions.getOffset(oldText, range.getEnd());
-                var builder = new StringBuilder();
-                builder.append(oldText.substring(0, offsetStart));
-                builder.append(change.getText());
-                builder.append(oldText.substring(offsetEnd));
-                oldText = builder.toString();
+                oldText = new StringBuilder()
+                    .append(oldText.substring(0, offsetStart))
+                    .append(change.getText())
+                    .append(oldText.substring(offsetEnd))
+                    .toString();
             }
             openFiles.put(uri, oldText);
         }

--- a/src/main/java/nextflow/lsp/file/FileCache.java
+++ b/src/main/java/nextflow/lsp/file/FileCache.java
@@ -92,22 +92,17 @@ public class FileCache {
         }
         else {
             // update file contents with incremental changes
-            var sortedChanges = new ArrayList<>(params.getContentChanges());
-            sortedChanges.sort((a, b) -> {
-                return Positions.COMPARATOR.compare( a.getRange().getStart(), b.getRange().getStart() );
-            });
-            var builder = new StringBuilder();
-            int previousEnd = 0;
-            for( var change : sortedChanges ) {
+            for( var change : params.getContentChanges() ) {
                 var range = change.getRange();
                 var offsetStart = Positions.getOffset(oldText, range.getStart());
                 var offsetEnd = Positions.getOffset(oldText, range.getEnd());
-                builder.append(oldText.substring(previousEnd, offsetStart));
+                var builder = new StringBuilder();
+                builder.append(oldText.substring(0, offsetStart));
                 builder.append(change.getText());
-                previousEnd = offsetEnd;
+                builder.append(oldText.substring(offsetEnd));
+                oldText = builder.toString();
             }
-            builder.append(oldText.substring(previousEnd));
-            openFiles.put(uri, builder.toString());
+            openFiles.put(uri, oldText);
         }
         changedFiles.add(uri);
     }

--- a/src/test/groovy/nextflow/lsp/file/FileCacheTest.groovy
+++ b/src/test/groovy/nextflow/lsp/file/FileCacheTest.groovy
@@ -61,7 +61,7 @@ class FileCacheTest extends Specification {
                     'hello'
                 ),
                 new TextDocumentContentChangeEvent(
-                    new Range(new Position(0, 8), new Position(0, 8)),
+                    new Range(new Position(0, 11), new Position(0, 11)),
                     ', friend'
                 )
             )


### PR DESCRIPTION
### Description
This PR fixes a bug in `FileCache.didChange()` that causes a `StringIndexOutOfBoundsException` when processing multiple incremental text changes in a single `didChange` event (#112). The issue occurs when LSP clients send character-by-character insertions as separate changes within the same event.

### Problem

The current implementation:
1. Sorts changes by start position
2. Applies all changes using positions relative to the original text
3. Uses a `previousEnd` pointer to track progress

This approach fails when changes modify text length because subsequent change positions become invalid.

### Solution

This patch:
- Removes the sorting logic (unnecessary for sequential application)
- Applies each change to the current text state
- Updates the text after each change to maintain correct positions

### Testing

This proposed fix seems to:
- allow the LSP to behave normally in Neovim v0.11 with mason-provided LSP v24.10.3 (pointing the LSP wrapper to the newly compiled jar).
- not trigger an error with the Python test script (#112) that would have otherwise reproduced the issue.

Please let me know if you have any questions! Happy to further improve the edit.