### PR TITLE
Bump Nextflow version to `25.06.0-edge`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ test {
 }
 
 dependencies {
-  implementation 'io.nextflow:nf-lang:25.05.0-edge'
+  implementation 'io.nextflow:nf-lang:25.06.0-edge'
   implementation 'org.apache.groovy:groovy:4.0.27'
   implementation 'org.apache.groovy:groovy-json:4.0.27'
   implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.0'


### PR DESCRIPTION
I ran into trouble when building the language server and managed to track it down to the recent [Nextflow version bump](https://github.com/nextflow-io/nextflow/commit/7d9272b78edaceedd80beeb63b15ed78b27bfffc). This PR updates the dependency to match the version in the `master` branch of Nextflow. If this is undesired, let me know and please ignore this PR.