### PR TITLE
Improve rendering of DAG preview

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ test {
 }
 
 dependencies {
-  implementation 'io.nextflow:nf-lang:25.05.0-edge'
+  implementation 'io.nextflow:nf-lang:25.06.0-edge'
   implementation 'org.apache.groovy:groovy:4.0.27'
   implementation 'org.apache.groovy:groovy-json:4.0.27'
   implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.0'

--- a/src/main/java/nextflow/lsp/NextflowLanguageServer.java
+++ b/src/main/java/nextflow/lsp/NextflowLanguageServer.java
@@ -306,7 +306,7 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
             var service = getLanguageService(uri);
             if( service == null )
                 return Collections.emptyList();
-            return service.codeLens(params);
+            return service.codeLens(params, configuration.showVariablesInDAG());
         });
     }
 
@@ -457,7 +457,8 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
             withDefault(JsonUtils.getBoolean(settings, "nextflow.formatting.maheshForm"), configuration.maheshForm()),
             withDefault(JsonUtils.getInteger(settings, "nextflow.completion.maxItems"), configuration.maxCompletionItems()),
             withDefault(JsonUtils.getBoolean(settings, "nextflow.formatting.sortDeclarations"), configuration.sortDeclarations()),
-            withDefault(JsonUtils.getBoolean(settings, "nextflow.typeChecking"), configuration.typeChecking())
+            withDefault(JsonUtils.getBoolean(settings, "nextflow.typeChecking"), configuration.typeChecking()),
+            withDefault(JsonUtils.getBoolean(settings, "nextflow.dag.showVariables"), configuration.showVariablesInDAG())
         );
 
         if( shouldInitialize(oldConfiguration, configuration) )
@@ -547,8 +548,9 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
         return CompletableFutures.computeAsync((cancelChecker) -> {
             cancelChecker.checkCanceled();
             var command = params.getCommand();
-            var arguments = params.getArguments();
+            List<Object> arguments = params.getArguments();
             if( "nextflow.server.previewDag".equals(command) && arguments.size() == 2 ) {
+                arguments.add(configuration.showVariablesInDAG());
                 log.debug(String.format("textDocument/previewDag %s", arguments.toString()));
                 var uri = JsonUtils.getString(arguments.get(0));
                 var service = getLanguageService(uri);

--- a/src/main/java/nextflow/lsp/NextflowLanguageServer.java
+++ b/src/main/java/nextflow/lsp/NextflowLanguageServer.java
@@ -306,7 +306,7 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
             var service = getLanguageService(uri);
             if( service == null )
                 return Collections.emptyList();
-            return service.codeLens(params, configuration.showVariablesInDAG());
+            return service.codeLens(params);
         });
     }
 
@@ -457,8 +457,7 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
             withDefault(JsonUtils.getBoolean(settings, "nextflow.formatting.maheshForm"), configuration.maheshForm()),
             withDefault(JsonUtils.getInteger(settings, "nextflow.completion.maxItems"), configuration.maxCompletionItems()),
             withDefault(JsonUtils.getBoolean(settings, "nextflow.formatting.sortDeclarations"), configuration.sortDeclarations()),
-            withDefault(JsonUtils.getBoolean(settings, "nextflow.typeChecking"), configuration.typeChecking()),
-            withDefault(JsonUtils.getBoolean(settings, "nextflow.dag.showVariables"), configuration.showVariablesInDAG())
+            withDefault(JsonUtils.getBoolean(settings, "nextflow.typeChecking"), configuration.typeChecking())
         );
 
         if( shouldInitialize(oldConfiguration, configuration) )
@@ -548,9 +547,8 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
         return CompletableFutures.computeAsync((cancelChecker) -> {
             cancelChecker.checkCanceled();
             var command = params.getCommand();
-            List<Object> arguments = params.getArguments();
+            var arguments = params.getArguments();
             if( "nextflow.server.previewDag".equals(command) && arguments.size() == 2 ) {
-                arguments.add(configuration.showVariablesInDAG());
                 log.debug(String.format("textDocument/previewDag %s", arguments.toString()));
                 var uri = JsonUtils.getString(arguments.get(0));
                 var service = getLanguageService(uri);

--- a/src/main/java/nextflow/lsp/NextflowLanguageServer.java
+++ b/src/main/java/nextflow/lsp/NextflowLanguageServer.java
@@ -450,6 +450,8 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
 
         var oldConfiguration = configuration;
         configuration = new LanguageServerConfiguration(
+            withDefault(JsonUtils.getString(settings, "nextflow.dag.direction"), configuration.dagDirection()),
+            withDefault(JsonUtils.getBoolean(settings, "nextflow.dag.verbose"), configuration.dagVerbose()),
             withDefault(errorReportingMode(settings), configuration.errorReportingMode()),
             withDefault(JsonUtils.getStringArray(settings, "nextflow.files.exclude"), configuration.excludePatterns()),
             withDefault(JsonUtils.getBoolean(settings, "nextflow.completion.extended"), configuration.extendedCompletion()),
@@ -553,14 +555,14 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
                 var uri = JsonUtils.getString(arguments.get(0));
                 var service = getLanguageService(uri);
                 if( service != null )
-                    return service.executeCommand(command, arguments);
+                    return service.executeCommand(command, arguments, configuration);
             }
             if( "nextflow.server.previewWorkspace".equals(command) && arguments.size() == 1 ) {
                 log.debug(String.format("textDocument/previewWorkspace %s", arguments.toString()));
                 var name = JsonUtils.getString(arguments.get(0));
                 var service = scriptServices.get(name);
                 if( service != null )
-                    return service.executeCommand(command, arguments);
+                    return service.executeCommand(command, arguments, configuration);
             }
             return null;
         });

--- a/src/main/java/nextflow/lsp/services/LanguageServerConfiguration.java
+++ b/src/main/java/nextflow/lsp/services/LanguageServerConfiguration.java
@@ -26,8 +26,7 @@ public record LanguageServerConfiguration(
     boolean maheshForm,
     int maxCompletionItems,
     boolean sortDeclarations,
-    boolean typeChecking,
-    boolean showVariablesInDAG
+    boolean typeChecking
 ) {
 
     public static LanguageServerConfiguration defaults() {
@@ -38,7 +37,6 @@ public record LanguageServerConfiguration(
             false,
             false,
             100,
-            false,
             false,
             false
         );

--- a/src/main/java/nextflow/lsp/services/LanguageServerConfiguration.java
+++ b/src/main/java/nextflow/lsp/services/LanguageServerConfiguration.java
@@ -19,6 +19,8 @@ import java.util.Collections;
 import java.util.List;
 
 public record LanguageServerConfiguration(
+    String dagDirection,
+    boolean dagVerbose,
     ErrorReportingMode errorReportingMode,
     List<String> excludePatterns,
     boolean extendedCompletion,
@@ -31,6 +33,8 @@ public record LanguageServerConfiguration(
 
     public static LanguageServerConfiguration defaults() {
         return new LanguageServerConfiguration(
+            "TB",
+            false,
             ErrorReportingMode.WARNINGS,
             Collections.emptyList(),
             false,

--- a/src/main/java/nextflow/lsp/services/LanguageServerConfiguration.java
+++ b/src/main/java/nextflow/lsp/services/LanguageServerConfiguration.java
@@ -26,7 +26,8 @@ public record LanguageServerConfiguration(
     boolean maheshForm,
     int maxCompletionItems,
     boolean sortDeclarations,
-    boolean typeChecking
+    boolean typeChecking,
+    boolean showVariablesInDAG
 ) {
 
     public static LanguageServerConfiguration defaults() {
@@ -37,6 +38,7 @@ public record LanguageServerConfiguration(
             false,
             false,
             100,
+            false,
             false,
             false
         );

--- a/src/main/java/nextflow/lsp/services/LanguageService.java
+++ b/src/main/java/nextflow/lsp/services/LanguageService.java
@@ -109,7 +109,7 @@ public abstract class LanguageService {
     public abstract boolean matchesFile(String uri);
     protected abstract ASTNodeCache getAstCache();
     protected CallHierarchyProvider getCallHierarchyProvider() { return null; }
-    protected CodeLensProvider getCodeLensProvider(boolean showVariablesInDAG) { return null; }
+    protected CodeLensProvider getCodeLensProvider() { return null; }
     protected CompletionProvider getCompletionProvider(int maxItems, boolean extended) { return null; }
     protected DefinitionProvider getDefinitionProvider() { return null; }
     protected FormattingProvider getFormattingProvider() { return null; }
@@ -186,8 +186,8 @@ public abstract class LanguageService {
         return provider.outgoingCalls(item);
     }
 
-    public List<CodeLens> codeLens(CodeLensParams params, boolean showVariablesInDAG) {
-        var provider = getCodeLensProvider(showVariablesInDAG);
+    public List<CodeLens> codeLens(CodeLensParams params) {
+        var provider = getCodeLensProvider();
         if( provider == null )
             return Collections.emptyList();
 

--- a/src/main/java/nextflow/lsp/services/LanguageService.java
+++ b/src/main/java/nextflow/lsp/services/LanguageService.java
@@ -109,7 +109,7 @@ public abstract class LanguageService {
     public abstract boolean matchesFile(String uri);
     protected abstract ASTNodeCache getAstCache();
     protected CallHierarchyProvider getCallHierarchyProvider() { return null; }
-    protected CodeLensProvider getCodeLensProvider() { return null; }
+    protected CodeLensProvider getCodeLensProvider(boolean showVariablesInDAG) { return null; }
     protected CompletionProvider getCompletionProvider(int maxItems, boolean extended) { return null; }
     protected DefinitionProvider getDefinitionProvider() { return null; }
     protected FormattingProvider getFormattingProvider() { return null; }
@@ -186,8 +186,8 @@ public abstract class LanguageService {
         return provider.outgoingCalls(item);
     }
 
-    public List<CodeLens> codeLens(CodeLensParams params) {
-        var provider = getCodeLensProvider();
+    public List<CodeLens> codeLens(CodeLensParams params, boolean showVariablesInDAG) {
+        var provider = getCodeLensProvider(showVariablesInDAG);
         if( provider == null )
             return Collections.emptyList();
 

--- a/src/main/java/nextflow/lsp/services/LanguageService.java
+++ b/src/main/java/nextflow/lsp/services/LanguageService.java
@@ -230,7 +230,7 @@ public abstract class LanguageService {
         return provider.documentSymbol(params.getTextDocument());
     }
 
-    public Object executeCommand(String command, List<Object> arguments) {
+    public Object executeCommand(String command, List<Object> arguments, LanguageServerConfiguration configuration) {
         return null;
     }
 

--- a/src/main/java/nextflow/lsp/services/script/ScriptCodeLensProvider.java
+++ b/src/main/java/nextflow/lsp/services/script/ScriptCodeLensProvider.java
@@ -41,9 +41,11 @@ public class ScriptCodeLensProvider implements CodeLensProvider {
     private static Logger log = Logger.getInstance();
 
     private ScriptAstCache ast;
+    private boolean showVariablesInDAG;
 
-    public ScriptCodeLensProvider(ScriptAstCache ast) {
+    public ScriptCodeLensProvider(ScriptAstCache ast, boolean showVariablesInDAG) {
         this.ast = ast;
+        this.showVariablesInDAG = showVariablesInDAG;
     }
 
     @Override
@@ -84,7 +86,7 @@ public class ScriptCodeLensProvider implements CodeLensProvider {
                 visitor.visit();
 
                 var graph = visitor.getGraph(wn.isEntry() ? "<entry>" : wn.getName());
-                var result = new MermaidRenderer().render(wn.getName(), graph);
+                var result = new MermaidRenderer(!showVariablesInDAG).render(wn.getName(), graph);
                 log.debug(result);
                 return Map.ofEntries(Map.entry("result", result));
             })

--- a/src/main/java/nextflow/lsp/services/script/ScriptCodeLensProvider.java
+++ b/src/main/java/nextflow/lsp/services/script/ScriptCodeLensProvider.java
@@ -70,7 +70,7 @@ public class ScriptCodeLensProvider implements CodeLensProvider {
         return result;
     }
 
-    public Map<String,String> previewDag(String documentUri, String name) {
+    public Map<String,String> previewDag(String documentUri, String name, String direction, boolean verbose) {
         var uri = URI.create(documentUri);
         if( !ast.hasAST(uri) || ast.hasErrors(uri) )
             return Map.of("error", "DAG preview cannot be shown because the script has errors.");
@@ -84,7 +84,7 @@ public class ScriptCodeLensProvider implements CodeLensProvider {
                 visitor.visit();
 
                 var graph = visitor.getGraph(wn.isEntry() ? "<entry>" : wn.getName());
-                var result = new MermaidRenderer().render(wn.getName(), graph);
+                var result = new MermaidRenderer(direction, verbose).render(wn.getName(), graph);
                 log.debug(result);
                 return Map.of("result", result);
             })

--- a/src/main/java/nextflow/lsp/services/script/ScriptCodeLensProvider.java
+++ b/src/main/java/nextflow/lsp/services/script/ScriptCodeLensProvider.java
@@ -41,11 +41,9 @@ public class ScriptCodeLensProvider implements CodeLensProvider {
     private static Logger log = Logger.getInstance();
 
     private ScriptAstCache ast;
-    private boolean showVariablesInDAG;
 
-    public ScriptCodeLensProvider(ScriptAstCache ast, boolean showVariablesInDAG) {
+    public ScriptCodeLensProvider(ScriptAstCache ast) {
         this.ast = ast;
-        this.showVariablesInDAG = showVariablesInDAG;
     }
 
     @Override
@@ -75,7 +73,7 @@ public class ScriptCodeLensProvider implements CodeLensProvider {
     public Map<String,String> previewDag(String documentUri, String name) {
         var uri = URI.create(documentUri);
         if( !ast.hasAST(uri) || ast.hasErrors(uri) )
-            return Map.ofEntries(Map.entry("error", "DAG preview cannot be shown because the script has errors."));
+            return Map.of("error", "DAG preview cannot be shown because the script has errors.");
 
         var sourceUnit = ast.getSourceUnit(uri);
         return ast.getWorkflowNodes(uri).stream()
@@ -86,9 +84,9 @@ public class ScriptCodeLensProvider implements CodeLensProvider {
                 visitor.visit();
 
                 var graph = visitor.getGraph(wn.isEntry() ? "<entry>" : wn.getName());
-                var result = new MermaidRenderer(!showVariablesInDAG).render(wn.getName(), graph);
+                var result = new MermaidRenderer().render(wn.getName(), graph);
                 log.debug(result);
-                return Map.ofEntries(Map.entry("result", result));
+                return Map.of("result", result);
             })
             .orElse(null);
     }

--- a/src/main/java/nextflow/lsp/services/script/ScriptCodeLensProvider.java
+++ b/src/main/java/nextflow/lsp/services/script/ScriptCodeLensProvider.java
@@ -80,7 +80,7 @@ public class ScriptCodeLensProvider implements CodeLensProvider {
             .filter(wn -> wn.isEntry() ? name == null : wn.getName().equals(name))
             .findFirst()
             .map((wn) -> {
-                var visitor = new DataflowVisitor(sourceUnit, ast);
+                var visitor = new DataflowVisitor(sourceUnit, ast, verbose);
                 visitor.visit();
 
                 var graph = visitor.getGraph(wn.isEntry() ? "<entry>" : wn.getName());

--- a/src/main/java/nextflow/lsp/services/script/ScriptService.java
+++ b/src/main/java/nextflow/lsp/services/script/ScriptService.java
@@ -71,8 +71,8 @@ public class ScriptService extends LanguageService {
     }
 
     @Override
-    protected CodeLensProvider getCodeLensProvider(boolean showVariablesInDAG) {
-        return new ScriptCodeLensProvider(astCache, showVariablesInDAG);
+    protected CodeLensProvider getCodeLensProvider() {
+        return new ScriptCodeLensProvider(astCache);
     }
 
     @Override
@@ -123,11 +123,10 @@ public class ScriptService extends LanguageService {
     @Override
     public Object executeCommand(String command, List<Object> arguments) {
         updateNow();
-        if( "nextflow.server.previewDag".equals(command) && arguments.size() == 3 ) {
+        if( "nextflow.server.previewDag".equals(command) && arguments.size() == 2 ) {
             var uri = getJsonString(arguments.get(0));
             var name = getJsonString(arguments.get(1));
-            boolean showVariablesInDAG = (boolean)arguments.get(2);
-            var provider = new ScriptCodeLensProvider(astCache, showVariablesInDAG);
+            var provider = new ScriptCodeLensProvider(astCache);
             return provider.previewDag(uri, name);
         }
         if( "nextflow.server.previewWorkspace".equals(command) ) {

--- a/src/main/java/nextflow/lsp/services/script/ScriptService.java
+++ b/src/main/java/nextflow/lsp/services/script/ScriptService.java
@@ -71,8 +71,8 @@ public class ScriptService extends LanguageService {
     }
 
     @Override
-    protected CodeLensProvider getCodeLensProvider() {
-        return new ScriptCodeLensProvider(astCache);
+    protected CodeLensProvider getCodeLensProvider(boolean showVariablesInDAG) {
+        return new ScriptCodeLensProvider(astCache, showVariablesInDAG);
     }
 
     @Override
@@ -123,10 +123,11 @@ public class ScriptService extends LanguageService {
     @Override
     public Object executeCommand(String command, List<Object> arguments) {
         updateNow();
-        if( "nextflow.server.previewDag".equals(command) && arguments.size() == 2 ) {
+        if( "nextflow.server.previewDag".equals(command) && arguments.size() == 3 ) {
             var uri = getJsonString(arguments.get(0));
             var name = getJsonString(arguments.get(1));
-            var provider = new ScriptCodeLensProvider(astCache);
+            boolean showVariablesInDAG = (boolean)arguments.get(2);
+            var provider = new ScriptCodeLensProvider(astCache, showVariablesInDAG);
             return provider.previewDag(uri, name);
         }
         if( "nextflow.server.previewWorkspace".equals(command) ) {

--- a/src/main/java/nextflow/lsp/services/script/ScriptService.java
+++ b/src/main/java/nextflow/lsp/services/script/ScriptService.java
@@ -121,13 +121,13 @@ public class ScriptService extends LanguageService {
     }
 
     @Override
-    public Object executeCommand(String command, List<Object> arguments) {
+    public Object executeCommand(String command, List<Object> arguments, LanguageServerConfiguration configuration) {
         updateNow();
         if( "nextflow.server.previewDag".equals(command) && arguments.size() == 2 ) {
             var uri = getJsonString(arguments.get(0));
             var name = getJsonString(arguments.get(1));
             var provider = new ScriptCodeLensProvider(astCache);
-            return provider.previewDag(uri, name);
+            return provider.previewDag(uri, name, configuration.dagDirection(), configuration.dagVerbose());
         }
         if( "nextflow.server.previewWorkspace".equals(command) ) {
             var provider = new WorkspacePreviewProvider(astCache);

--- a/src/main/java/nextflow/lsp/services/script/dag/DataflowVisitor.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/DataflowVisitor.java
@@ -306,12 +306,11 @@ public class DataflowVisitor extends ScriptVisitorSupport {
         current.pushSubgraph(controlDn);
         var truePreds = visitWithPreds(node.getTrueExpression());
         current.popSubgraph();
+        currentPreds().addAll(truePreds);
 
         current.pushSubgraph(controlDn);
         var falsePreds = visitWithPreds(node.getFalseExpression());
         current.popSubgraph();
-
-        currentPreds().addAll(truePreds);
         currentPreds().addAll(falsePreds);
     }
 

--- a/src/main/java/nextflow/lsp/services/script/dag/DataflowVisitor.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/DataflowVisitor.java
@@ -1,32 +1,30 @@
 /*
  * Copyright 2024-2025, Seqera Labs
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package nextflow.lsp.services.script.dag;
 
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
-import java.util.function.Function;
+import java.util.stream.Collectors;
 
-import groovy.lang.Tuple2;
 import groovy.lang.Tuple3;
 import nextflow.lsp.services.script.ScriptAstCache;
 import nextflow.script.ast.ASTNodeMarker;
@@ -50,76 +48,23 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.*;
  * @author Ben Sherman <bentshermann@gmail.com>
  * @author Erik Danielsson <danielsson.erik.0@gmail.com>
  */
-
-class Variable {
-    private int definitionDepth;
-    private Set<Node> activeInstances;
-    private Node.Type type;
-
-    public Variable(Node activeInstance, int definitionDepth) {
-        this.activeInstances = new HashSet<>();
-        activeInstances.add(activeInstance);
-        this.definitionDepth = definitionDepth;
-        type = activeInstance.type;
-    }
-
-    private Variable(Set<Node> activeInstances, int definitionDepth) {
-        this.activeInstances = new HashSet<>(activeInstances);
-        this.definitionDepth = definitionDepth;
-    }
-
-    public Node.Type getType() {
-        return type;
-    }
-
-    public Variable shallowCopy() {
-        return new Variable(activeInstances, definitionDepth);
-    }
-
-    public boolean isLocal(int currDepth) {
-        return definitionDepth == currDepth;
-    }
-
-    public int getDefinitionDepth() {
-        return definitionDepth;
-    }
-
-    public Set<Node> getActiveInstances() {
-        return activeInstances;
-    }
-
-    public void setActiveInstance(Node dn) {
-        activeInstances.clear();
-        activeInstances.add(dn);
-    }
-
-    public Variable union(Variable other) {
-        var unionInstances = new HashSet<>(activeInstances);
-        unionInstances.addAll(other.getActiveInstances());
-        return new Variable(unionInstances, definitionDepth);
-    }
-}
-
 public class DataflowVisitor extends ScriptVisitorSupport {
 
     private SourceUnit sourceUnit;
 
     private ScriptAstCache ast;
 
-    private Map<String, Graph> graphs = new HashMap<>();
+    private Map<String,Graph> graphs = new HashMap<>();
 
     private Stack<Set<Node>> stackPreds = new Stack<>();
 
-    private Stack<Map<String, Variable>> conditionalScopes = new Stack<>();
-
-    private int currentDepth = 0;
+    private VariableContext vc = new VariableContext();
 
     public DataflowVisitor(SourceUnit sourceUnit, ScriptAstCache ast) {
         this.sourceUnit = sourceUnit;
         this.ast = ast;
 
         stackPreds.add(new HashSet<>());
-        conditionalScopes.push(new HashMap<>());
     }
 
     @Override
@@ -147,107 +92,6 @@ public class DataflowVisitor extends ScriptVisitorSupport {
 
     private boolean inEntry;
 
-    public Set<Node> getSymbolConditionalScope(String name) {
-        // get a variable node from the name table
-        var scope = conditionalScopes.peek();
-        if( scope.containsKey(name) ) {
-            return scope.get(name).getActiveInstances();
-        } else {
-            return null;
-        }
-    }
-
-    public void putSymbolConditionalScope(String name, Node dn, boolean isLocal) {
-
-        // Put a symbol into the currently active symbol table
-        var scope = conditionalScopes.peek();
-
-        if( scope.containsKey(name) ) {
-
-            // We have reassinged the variable, which means that all previous
-            // definitions of it (in this scope) are dead. We can reuse the set
-            // though
-            Variable variable = scope.get(name);
-            variable.setActiveInstance(dn);
-
-        } else {
-
-            // The symbols in not present from before so create an empty set
-            Variable variable = new Variable(dn, isLocal ? currentDepth : 0);
-            scope.put(name, variable);
-
-        }
-    }
-
-    public void pushConditionalScope(Map<String, Variable> previousSymbols) {
-
-        // We want to add all symbols in the current scope
-        // since they always enter both branches
-        var newScope = new HashMap<String, Variable>();
-
-        for( Map.Entry<String, Variable> entry : previousSymbols.entrySet() ) {
-            newScope.put(entry.getKey(), entry.getValue().shallowCopy());
-        }
-
-        conditionalScopes.push(newScope);
-    }
-
-    public Map<String, Variable> popConditionalScope() {
-        return conditionalScopes.pop();
-    }
-
-    public Map<String, Variable> mergeConditionalScopes(Map<String, Variable> ifSymbols,
-            Map<String, Variable> elseSymbols, Subgraph ifSubgraph, Subgraph elseSubgraph) {
-        // Merge the set nodes corresponding to active symbols for the two scopes
-        var merged = new HashMap<String, Variable>();
-        // Add all keys from ifSymbols
-        for( Map.Entry<String, Variable> entry : ifSymbols.entrySet() ) {
-            String key = entry.getKey();
-            Variable ifVariable = entry.getValue();
-            if( ifVariable.getDefinitionDepth() <= currentDepth ) {
-                if( elseSymbols.containsKey(key) ) {
-                    merged.put(key, ifVariable.union(elseSymbols.get(key)));
-                } else {
-                    // The variable is only found in the else branch, so we should add a null
-                    // initializer to it
-                    if( ifVariable.getType() == Node.Type.NAME ) {
-                        Node uninitNode = fixUninitNodeSubgraph(key, elseSubgraph);
-                        merged.put(key, ifVariable.union(new Variable(uninitNode, 0)));
-                    } else {
-                        merged.put(key, ifVariable.shallowCopy());
-                    }
-                }
-            }
-        }
-
-        // Add remaining keys from elseSymbols (already handled common ones)
-        for( Map.Entry<String, Variable> entry : elseSymbols.entrySet() ) {
-            String key = entry.getKey();
-            Variable elseVariable = entry.getValue();
-            if( !merged.containsKey(key) && elseVariable.getDefinitionDepth() <= currentDepth ) {
-                // The variable is only found in the if branch, so we should add a null
-                // initializer to it
-                if( elseVariable.getType() == Node.Type.NAME ) {
-                    Node uninitNode = fixUninitNodeSubgraph(key, ifSubgraph);
-                    merged.put(key, elseVariable.union(new Variable(uninitNode, 0)));
-                } else {
-                    merged.put(key, elseVariable.shallowCopy());
-                }
-            }
-        }
-
-        return merged;
-    }
-
-    private Node fixUninitNodeSubgraph(String label, Subgraph subgraph) {
-        var nullAndUninitNode = addUninitalizedNode(label, null);
-        var nullNode = nullAndUninitNode.getV1();
-        var uninitNode = nullAndUninitNode.getV2();
-        subgraph.addMember(nullNode);
-        subgraph.addMember(uninitNode);
-        return uninitNode;
-    }
-
     @Override
     public void visitWorkflow(WorkflowNode node) {
         current = new Graph();
@@ -264,42 +108,39 @@ public class DataflowVisitor extends ScriptVisitorSupport {
         current = null;
     }
 
-    private void visitWorkflowTakes(WorkflowNode node, Map<String, Node> result) {
+    private void visitWorkflowTakes(WorkflowNode node, Map<String,Node> result) {
         for( var stmt : asBlockStatements(node.takes) ) {
             var name = asVarX(stmt).getName();
             var dn = addNode(name, Node.Type.NAME, stmt);
-            putSymbolConditionalScope(name, dn, false);
+            vc.putSymbol(name, dn);
             result.put(name, dn);
         }
     }
 
-    private void visitWorkflowEmits(WorkflowNode node, Map<String, Node> result) {
+    private void visitWorkflowEmits(WorkflowNode node, Map<String,Node> result) {
         for( var stmt : asBlockStatements(node.emits) ) {
             var emit = ((ExpressionStatement) stmt).getExpression();
             String name;
             if( emit instanceof VariableExpression ve ) {
                 name = ve.getName();
-            } else if( emit instanceof AssignmentExpression assign ) {
+            }
+            else if( emit instanceof AssignmentExpression assign ) {
                 var target = (VariableExpression) assign.getLeftExpression();
                 name = target.getName();
                 visit(emit);
-            } else {
+            }
+            else {
                 name = "$out";
                 visit(new AssignmentExpression(varX(name), emit));
             }
-            var dns = getSymbolConditionalScope(name);
-            if( dns == null ) {
+            var dn = getSymbol(name);
+            if( dn == null )
                 System.err.println("missing emit: " + name);
-                result.put(name, null);
-            } else if( dns.size() > 1 ) {
-                System.err.println("two many emits: " + name);
-            } else {
-                result.put(name, dns.iterator().next());
-            }
+            result.put(name, dn);
         }
     }
 
-    private void visitWorkflowPublishers(WorkflowNode node, Map<String, Node> result) {
+    private void visitWorkflowPublishers(WorkflowNode node, Map<String,Node> result) {
         for( var stmt : asBlockStatements(node.publishers) ) {
             var es = (ExpressionStatement) stmt;
             var publisher = (BinaryExpression) es.getExpression();
@@ -307,11 +148,48 @@ public class DataflowVisitor extends ScriptVisitorSupport {
             var source = publisher.getRightExpression();
             visit(new AssignmentExpression(target, source));
             var name = target.getName();
-            var dns = getSymbolConditionalScope(name);
-            if( dns.size() == 1 ) {
-                result.put(name, dns.iterator().next());
-            }
+            var dn = getSymbol(name);
+            if( dn == null )
+                System.err.println("missing publisher: " + name);
+            result.put(name, dn);
         }
+    }
+
+    // statements
+
+    @Override
+    public void visitIfElse(IfStatement node) {
+        // visit the conditional expression
+        var preds = visitWithPreds(node.getBooleanExpression());
+        var controlDn = addNode("", Node.Type.CONTROL, null, preds);
+
+        // visit the if branch
+        vc.pushScope();
+        current.pushSubgraph(controlDn);
+        visitWithPreds(node.getIfBlock());
+
+        var ifScope = vc.popScope();
+        var ifSubgraph = current.popSubgraph();
+
+        // visit the else branch
+        Map<String,Variable> elseScope;
+
+        if( !node.getElseBlock().isEmpty() ) {
+            vc.pushScope();
+            current.pushSubgraph(controlDn);
+            visitWithPreds(node.getElseBlock());
+
+            elseScope = vc.popScope();
+            current.popSubgraph();
+        }
+        else {
+            // if there is no else branch, then the set of active symbols
+            // after the if statement is the union of the active symbols
+            // from before the if and the active symbols in the if
+            elseScope = vc.peekScope();
+        }
+
+        vc.mergeConditionalScopes(ifScope, elseScope);
     }
 
     // expressions
@@ -334,7 +212,7 @@ public class DataflowVisitor extends ScriptVisitorSupport {
         if( defNode instanceof WorkflowNode || defNode instanceof ProcessNode ) {
             var preds = visitWithPreds(node.getArguments());
             var dn = addNode(name, Node.Type.OPERATOR, defNode, preds);
-            putSymbolConditionalScope(name, dn, false);
+            vc.putSymbol(name, dn);
             return;
         }
 
@@ -355,103 +233,25 @@ public class DataflowVisitor extends ScriptVisitorSupport {
         super.visitBinaryExpression(node);
     }
 
-    @Override
-    public void visitIfElse(IfStatement node) {
-
-        // First visit the conditional
-        var preds = visitWithPreds(node.getBooleanExpression());
-        var conditionalDn = addNode("<conditional>", Node.Type.CONDITIONAL, node, preds);
-
-        // Then construct new symbol tables for each of the branches
-        // Get the symbol table associated with the currently available global
-        // variables
-        var precedingScope = popConditionalScope();
-
-        // Construct the scope for the if branch
-        pushConditionalScope(precedingScope);
-        currentDepth += 1;
-
-        current.pushSubgraph();
-        current.putSubgraphPred(conditionalDn);
-
-        visitWithPreds(node.getIfBlock());
-
-        var ifScope = popConditionalScope();
-        var ifSubgraph = current.popSubgraph();
-
-        Map<String, Variable> elseScope;
-        Subgraph elseSubgraph;
-        if( !node.getElseBlock().isEmpty() ) {
-
-            // We push a new symbol table to keep track of the
-            // symbols in the else branch.
-            pushConditionalScope(precedingScope);
-
-            // Push a new subgraph to keep track of the else branch
-            current.pushSubgraph();
-            current.putSubgraphPred(conditionalDn);
-            visitWithPreds(node.getElseBlock());
-
-            // Exit the else branch
-            elseScope = popConditionalScope();
-            elseSubgraph = current.popSubgraph();
-
-        } else {
-
-            // If there is only an if branch then the active symbols after the statement
-            // is the union of the active symbols from before the if and the active symbols
-            // in the if
-            elseScope = precedingScope;
-            elseSubgraph = current.peekSubgraph();
-
-        }
-
-        currentDepth -= 1;
-        var succedingScope = mergeConditionalScopes(ifScope, elseScope, ifSubgraph, elseSubgraph);
-        pushConditionalScope(succedingScope);
-
-    }
-
-    private void visitAssignment(BinaryExpression node, boolean isDef) {
-
-        var targetExpr = node.getLeftExpression();
-        var sourceExpr = node.getRightExpression();
-
-        if( targetExpr instanceof TupleExpression tupleExpr && sourceExpr instanceof ListExpression listExpr ) {
-
-            // e.g. (x, y, z) = [1, 2, 3].
-            // We need to keep track what variable is assigned where
-            List<Expression> targetExprList = tupleExpr.getExpressions();
-            List<Expression> sourceExprList = listExpr.getExpressions();
-
-            // We need to wait with adding the nodes, so that we do not overwrite live
-            // variable names in the source expression
-            List<Tuple2<String, Set<Node>>> namesAndPreds = new ArrayList<>();
-
-            for( int i = 0; i < Math.min(targetExprList.size(), sourceExprList.size()); i++ ) {
-                String name = getAssignmentTarget(targetExprList.get(i)).getName();
-                var preds = visitWithPreds(sourceExprList.get(i));
-                namesAndPreds.add(new Tuple2<>(name, preds));
-            }
-
-            for( var namePreds : namesAndPreds ) {
-                var name = namePreds.getV1();
-                var preds = namePreds.getV2();
-                var dn = addNode(name, Node.Type.NAME, null, preds);
-                putSymbolConditionalScope(name, dn, isDef);
-            }
-        } else {
-
-            processAssignment(targetExpr, sourceExpr, isDef);
-
+    private void visitAssignment(BinaryExpression node, boolean isLocal) {
+        var preds = visitWithPreds(node.getRightExpression());
+        var targets = getAssignmentTargets(node.getLeftExpression());
+        for( var name : targets ) {
+            var dn = addNode(name, Node.Type.NAME, null, preds);
+            vc.putSymbol(name, dn, isLocal);
         }
     }
 
-    private void processAssignment(Expression target, Expression source, boolean isDef) {
-        String name = getAssignmentTarget(target).getName();
-        var preds = visitWithPreds(source);
-        var dn = addNode(name, Node.Type.NAME, null, preds);
-        putSymbolConditionalScope(name, dn, isDef);
+    private Set<String> getAssignmentTargets(Expression node) {
+        // e.g. (x, y, z) = xyz
+        if( node instanceof TupleExpression te ) {
+            return te.getExpressions().stream()
+                .map(el -> getAssignmentTarget(el).getName())
+                .collect(Collectors.toSet());
+        }
+        else {
+            return Set.of(getAssignmentTarget(node).getName());
+        }
     }
 
     private VariableExpression getAssignmentTarget(Expression node) {
@@ -478,7 +278,7 @@ public class DataflowVisitor extends ScriptVisitorSupport {
                 var label = defNode.getName();
                 var preds = visitWithPreds(lhs);
                 var dn = addNode(label, Node.Type.OPERATOR, defNode, preds);
-                putSymbolConditionalScope(label, dn, false);
+                vc.putSymbol(label, dn);
                 return;
             }
         }
@@ -493,6 +293,7 @@ public class DataflowVisitor extends ScriptVisitorSupport {
 
     @Override
     public void visitClosureExpression(ClosureExpression node) {
+        // skip closures since they can't contain dataflow logic
     }
 
     @Override
@@ -528,21 +329,20 @@ public class DataflowVisitor extends ScriptVisitorSupport {
         return inEntry && node.getObjectExpression() instanceof VariableExpression ve && "params".equals(ve.getName());
     }
 
-    private Tuple3<MethodNode, String, String> asMethodOutput(PropertyExpression node) {
+    private Tuple3<MethodNode,String,String> asMethodOutput(PropertyExpression node) {
         // named output e.g. PROC.out.foo
         if( node.getObjectExpression() instanceof PropertyExpression pe ) {
             if( pe.getObjectExpression() instanceof VariableExpression ve && "out".equals(pe.getPropertyAsString()) ) {
                 var mn = asMethodVariable(ve.getAccessedVariable());
                 if( mn != null )
-                    return new Tuple3<MethodNode, String, String>(mn, ve.getName(), node.getPropertyAsString());
+                    return new Tuple3(mn, ve.getName(), node.getPropertyAsString());
             }
         }
         // single output e.g. PROC.out
-        else if( node.getObjectExpression() instanceof VariableExpression ve
-                && "out".equals(node.getPropertyAsString()) ) {
+        else if( node.getObjectExpression() instanceof VariableExpression ve && "out".equals(node.getPropertyAsString()) ) {
             var mn = asMethodVariable(ve.getAccessedVariable());
             if( mn != null )
-                return new Tuple3<MethodNode, String, String>(mn, ve.getName(), null);
+                return new Tuple3(mn, ve.getName(), null);
         }
         return null;
     }
@@ -552,21 +352,29 @@ public class DataflowVisitor extends ScriptVisitorSupport {
             addOperatorPred(label, process);
             return;
         }
-        asDirectives(process.outputs).filter((call) -> {
-            var emitName = getProcessEmitName(call);
-            return propName.equals(emitName);
-        }).findFirst().ifPresent((call) -> {
-            addOperatorPred(label, process);
-        });
+        asDirectives(process.outputs)
+            .filter((call) -> {
+                var emitName = getProcessEmitName(call);
+                return propName.equals(emitName);
+            })
+            .findFirst()
+            .ifPresent((call) -> {
+                addOperatorPred(label, process);
+            });
     }
 
     private String getProcessEmitName(MethodCallExpression output) {
-        return Optional.of(output).flatMap(call -> Optional.ofNullable(asNamedArgs(call)))
-                .flatMap(namedArgs -> namedArgs.stream()
-                        .filter(entry -> "emit".equals(entry.getKeyExpression().getText())).findFirst())
-                .flatMap(entry -> Optional
-                        .ofNullable(entry.getValueExpression() instanceof VariableExpression ve ? ve.getName() : null))
-                .orElse(null);
+        return Optional.of(output)
+            .flatMap(call -> Optional.ofNullable(asNamedArgs(call)))
+            .flatMap(namedArgs ->
+                namedArgs.stream()
+                    .filter(entry -> "emit".equals(entry.getKeyExpression().getText()))
+                    .findFirst()
+            )
+            .flatMap(entry -> Optional.ofNullable(
+                entry.getValueExpression() instanceof VariableExpression ve ? ve.getName() : null
+            ))
+            .orElse(null);
     }
 
     private void visitWorkflowOut(WorkflowNode workflow, String label, String propName) {
@@ -574,19 +382,23 @@ public class DataflowVisitor extends ScriptVisitorSupport {
             addOperatorPred(label, workflow);
             return;
         }
-        asBlockStatements(workflow.emits).stream().map(stmt -> ((ExpressionStatement) stmt).getExpression())
-                .filter((emit) -> {
-                    var emitName = getWorkflowEmitName(emit);
-                    return propName.equals(emitName);
-                }).findFirst().ifPresent((call) -> {
-                    addOperatorPred(label, workflow);
-                });
+        asBlockStatements(workflow.emits).stream()
+            .map(stmt -> ((ExpressionStatement) stmt).getExpression())
+            .filter((emit) -> {
+                var emitName = getWorkflowEmitName(emit);
+                return propName.equals(emitName);
+            })
+            .findFirst()
+            .ifPresent((call) -> {
+                addOperatorPred(label, workflow);
+            });
     }
 
     private String getWorkflowEmitName(Expression emit) {
         if( emit instanceof VariableExpression ve ) {
             return ve.getName();
-        } else if( emit instanceof AssignmentExpression assign ) {
+        }
+        else if( emit instanceof AssignmentExpression assign ) {
             var target = (VariableExpression) assign.getLeftExpression();
             return target.getName();
         }
@@ -594,28 +406,31 @@ public class DataflowVisitor extends ScriptVisitorSupport {
     }
 
     private void addOperatorPred(String label, ASTNode an) {
-        Set<Node> dns = getSymbolConditionalScope(label);
-        if( dns != null ) {
-            for( var dn : dns ) {
-                currentPreds().add(dn);
-            }
-        } else {
-            var dn = addNode(label, Node.Type.OPERATOR, an);
-            putSymbolConditionalScope(label, dn, false);
-        }
+        var dn = getSymbol(label);
+        if( dn != null )
+            currentPreds().add(dn);
+        else
+            vc.putSymbol(label, addNode(label, Node.Type.OPERATOR, an));
     }
 
     @Override
     public void visitVariableExpression(VariableExpression node) {
         var name = node.getName();
-        Set<Node> dns = getSymbolConditionalScope(name);
-        if( dns != null )
-            for( Node dn : dns ) {
-                currentPreds().add(dn);
-            }
+        var dn = getSymbol(name);
+        if( dn != null )
+            currentPreds().add(dn);
     }
 
     // helpers
+
+    private Node getSymbol(String name) {
+        var preds = vc.getSymbol(name);
+        if( preds.isEmpty() )
+            return null;
+        if( preds.size() == 1 )
+            return preds.iterator().next();
+        return addNode(name, Node.Type.NAME, null, preds);
+    }
 
     private Set<Node> currentPreds() {
         return stackPreds.peek();
@@ -645,206 +460,7 @@ public class DataflowVisitor extends ScriptVisitorSupport {
     }
 
     private Node addNode(String label, Node.Type type, ASTNode an) {
-        var dn = addNode(label, type, an, new HashSet<>());
-        return dn;
+        return addNode(label, type, an, new HashSet<>());
     }
 
-    private Tuple2<Node, Node> addUninitalizedNode(String label, ASTNode an) {
-        var nullNode = addNode("null", Node.Type.NULL, an);
-        var preds = new HashSet<Node>();
-        preds.add(nullNode);
-        var uninitalizedNode = current.addNode(label, Node.Type.NAME, null, preds);
-        return new Tuple2<>(nullNode, uninitalizedNode);
-    }
-
-}
-
-class Graph {
-
-    public final Map<String, Node> inputs = new HashMap<>();
-
-    public final Map<Integer, Node> nodes = new HashMap<>();
-
-    public final Map<String, Node> outputs = new HashMap<>();
-
-    private Stack<Map<String, Node>> scopes = new Stack<>();
-
-    public Stack<Subgraph> activeSubgraphs = new Stack<>();
-
-    private int currSubgraphId = 0;
-
-    public Graph() {
-        pushScope();
-        pushSubgraph();
-    }
-
-    public void pushScope() {
-        scopes.add(0, new HashMap<>());
-    }
-
-    public void popScope() {
-        scopes.remove(0);
-    }
-
-    public void pushSubgraph() {
-        activeSubgraphs.push(new Subgraph(currSubgraphId));
-        currSubgraphId += 1;
-    }
-
-    public Subgraph popSubgraph() {
-        var prevSubgraph = activeSubgraphs.pop();
-        var currSubgraph = activeSubgraphs.peek();
-        currSubgraph.addChild(prevSubgraph);
-        return prevSubgraph;
-    }
-
-    public Subgraph peekSubgraph() {
-        return activeSubgraphs.peek();
-    }
-
-    public void putToSubgraph(Node n) {
-        activeSubgraphs.peek().addMember(n);
-    }
-
-    public void putSubgraphPred(Node n) {
-        activeSubgraphs.peek().addPred(n);
-    }
-
-    public Node addNode(String label, Node.Type type, URI uri, Set<Node> preds) {
-        var id = nodes.size();
-        var dn = new Node(id, label, type, uri, preds);
-        nodes.put(id, dn);
-        putToSubgraph(dn);
-        return dn;
-    }
-
-    public void collapseGraph(Function<Node, Boolean> hide, Function<Node, Boolean> hideIfDisconnected) {
-        // We want to collapse the graph by removing all nodes satisfying the predicate `isHidden`
-        // and then look for disconnected nodes which should be hidden if they satisfy `hideIfDisconnected`
-        Set<Integer> visited = new HashSet<>();
-        Set<Integer> remove = new HashSet<>();
-        Set<Integer> maybeRemove = new HashSet<>();
-        for (Map.Entry<Integer, Node> idNode : nodes.entrySet()) {
-            int id = idNode.getKey();
-            Node node = idNode.getValue();
-            if (!hide.apply(node)) {
-                if (!hideIfDisconnected.apply(node)) {
-                    // We have found a node that should always be connected, start searching from here
-                    findTrueAncestors(node, hide, visited);
-                    visited.add(id);
-                } else {
-                    maybeRemove.add(id);
-                }
-            } else {
-                remove.add(id);
-            }
-        }
-        // If a node was visited then it is necessarily connected to a node we are keeping
-        maybeRemove.removeAll(visited); 
-        remove.addAll(maybeRemove);
-
-        for (int id : remove) 
-            nodes.remove(id);
-        
-    }
-
-    private Set<Node> findTrueAncestors(Node node, Function<Node, Boolean> hide, Set<Integer> visited) {
-        Set<Node> truePreds = new HashSet<>();
-        for (Node pred : node.preds) {
-            if (!hide.apply(pred)) {
-                truePreds.add(pred);
-            } else if (!visited.contains(pred.id)) {
-                var predAncestors = findTrueAncestors(pred, hide, visited);
-                truePreds.addAll(predAncestors);
-            } else {
-                // We have already visited the node and have found its ancestors
-                truePreds.addAll(pred.preds);
-            }
-            visited.add(pred.id);
-        }
-        node.preds.clear();
-        node.preds.addAll(truePreds);
-        return truePreds;
-    }
-    
-}
-class Subgraph {
-
-    private int id;
-
-    private List<Subgraph> children = new ArrayList<>();
-
-    private Set<Node> members = new HashSet<>();
-
-    private Set<Node> preds = new HashSet<>();
-
-    public Subgraph(int id) {
-        this.id = id;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void addMember(Node n) {
-        members.add(n);
-    }
-
-    public Set<Node> getMembers() {
-        return members;
-    }
-
-    public void addChild(Subgraph s) {
-        children.add(s);
-    }
-
-    public List<Subgraph> getChildren() {
-        return children;
-    }
-
-    public Set<Node> getPreds() {
-        return preds;
-    }
-
-    public void addPred(Node n) {
-        preds.add(n);
-    }
-}
-class Node {
-    public enum Type {
-        NAME, OPERATOR, CONDITIONAL, NULL
-    }
-
-    public final int id;
-    public final String label;
-    public final Type type;
-    public final URI uri;
-    public final Set<Node> preds;
-
-    public Node(int id, String label, Type type, URI uri, Set<Node> preds) {
-        this.id = id;
-        this.label = label;
-        this.type = type;
-        this.uri = uri;
-        this.preds = preds;
-    }
-
-    public void addPredecessors(Set<Node> preds) {
-        this.preds.addAll(preds);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        return other instanceof Node n && this.id == n.id;
-    }
-
-    @Override
-    public int hashCode() {
-        return id;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("id=%s,label='%s',type=%s", id, label, type);
-    }
 }

--- a/src/main/java/nextflow/lsp/services/script/dag/DataflowVisitor.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/DataflowVisitor.java
@@ -64,15 +64,18 @@ public class DataflowVisitor extends ScriptVisitorSupport {
 
     private ScriptAstCache ast;
 
+    private boolean verbose;
+
     private Map<String,Graph> graphs = new HashMap<>();
 
     private Stack<Set<Node>> stackPreds = new Stack<>();
 
     private VariableContext vc = new VariableContext();
 
-    public DataflowVisitor(SourceUnit sourceUnit, ScriptAstCache ast) {
+    public DataflowVisitor(SourceUnit sourceUnit, ScriptAstCache ast, boolean verbose) {
         this.sourceUnit = sourceUnit;
         this.ast = ast;
+        this.verbose = verbose;
 
         stackPreds.push(new HashSet<>());
     }
@@ -197,7 +200,7 @@ public class DataflowVisitor extends ScriptVisitorSupport {
         }
 
         // hide if-else statement if both subgraphs are empty
-        if( ifSubgraph.isVerbose() && (elseSubgraph == null || elseSubgraph.isVerbose()) ) {
+        if( !verbose && ifSubgraph.isVerbose() && (elseSubgraph == null || elseSubgraph.isVerbose()) ) {
             controlDn.verbose = true;
             for( var name : outputs )
                 getSymbol(name).preds.addAll(controlPreds);

--- a/src/main/java/nextflow/lsp/services/script/dag/Graph.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/Graph.java
@@ -51,12 +51,12 @@ class Graph {
     }
 
     public void pushSubgraph() {
-        subgraphs.push(new Subgraph(nextSubgraphId, Collections.emptySet()));
+        subgraphs.push(new Subgraph(nextSubgraphId, null));
         nextSubgraphId += 1;
     }
 
     public void pushSubgraph(Node dn) {
-        subgraphs.push(new Subgraph(nextSubgraphId, Set.of(dn)));
+        subgraphs.push(new Subgraph(nextSubgraphId, dn));
         nextSubgraphId += 1;
     }
 
@@ -80,15 +80,15 @@ class Subgraph {
 
     public final int id;
 
-    public final Set<Node> preds;
+    public final Node pred;
 
     public final List<Subgraph> subgraphs = new ArrayList<>();
 
     public final Set<Node> nodes = new HashSet<>();
 
-    public Subgraph(int id, Set<Node> preds) {
+    public Subgraph(int id, Node pred) {
         this.id = id;
-        this.preds = preds;
+        this.pred = pred;
     }
 }
 

--- a/src/main/java/nextflow/lsp/services/script/dag/Graph.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/Graph.java
@@ -90,6 +90,20 @@ class Subgraph {
         this.id = id;
         this.pred = pred;
     }
+
+    public boolean isVerbose() {
+        return nodes.stream().allMatch(n -> n.verbose);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof Subgraph s && this.id == s.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
+    }
 }
 
 
@@ -106,12 +120,15 @@ class Node {
     public final URI uri;
     public final Set<Node> preds;
 
+    public boolean verbose;
+
     public Node(int id, String label, Type type, URI uri, Set<Node> preds) {
         this.id = id;
         this.label = label;
         this.type = type;
         this.uri = uri;
         this.preds = preds;
+        this.verbose = (type == Type.NAME);
     }
 
     public void addPredecessors(Set<Node> preds) {
@@ -130,6 +147,7 @@ class Node {
 
     @Override
     public String toString() {
-        return String.format("id=%s,label='%s',type=%s", id, label, type);
+        var predIds = preds.stream().map(p -> p.id).toList();
+        return String.format("id=%s,label='%s',type=%s,preds=%s", id, label, type, predIds);
     }
 }

--- a/src/main/java/nextflow/lsp/services/script/dag/Graph.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/Graph.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lsp.services.script.dag;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ * @author Erik Danielsson <danielsson.erik.0@gmail.com>
+ */
+class Graph {
+
+    public final Map<String,Node> inputs = new HashMap<>();
+
+    public final Map<Integer,Node> nodes = new HashMap<>();
+
+    public final Map<String,Node> outputs = new HashMap<>();
+
+    private Stack<Subgraph> subgraphs = new Stack<>();
+
+    private int nextSubgraphId = 0;
+
+    public Graph() {
+        pushSubgraph();
+    }
+
+    public Subgraph peekSubgraph() {
+        return subgraphs.peek();
+    }
+
+    public void pushSubgraph() {
+        subgraphs.push(new Subgraph(nextSubgraphId, Collections.emptySet()));
+        nextSubgraphId += 1;
+    }
+
+    public void pushSubgraph(Node dn) {
+        subgraphs.push(new Subgraph(nextSubgraphId, Set.of(dn)));
+        nextSubgraphId += 1;
+    }
+
+    public Subgraph popSubgraph() {
+        var result = subgraphs.pop();
+        subgraphs.peek().subgraphs.add(result);
+        return result;
+    }
+
+    public Node addNode(String label, Node.Type type, URI uri, Set<Node> preds) {
+        var id = nodes.size();
+        var dn = new Node(id, label, type, uri, preds);
+        nodes.put(id, dn);
+        subgraphs.peek().nodes.add(dn);
+        return dn;
+    }
+}
+
+
+class Subgraph {
+
+    public final int id;
+
+    public final Set<Node> preds;
+
+    public final List<Subgraph> subgraphs = new ArrayList<>();
+
+    public final Set<Node> nodes = new HashSet<>();
+
+    public Subgraph(int id, Set<Node> preds) {
+        this.id = id;
+        this.preds = preds;
+    }
+}
+
+
+class Node {
+    public enum Type {
+        NAME,
+        OPERATOR,
+        CONTROL
+    }
+
+    public final int id;
+    public final String label;
+    public final Type type;
+    public final URI uri;
+    public final Set<Node> preds;
+
+    public Node(int id, String label, Type type, URI uri, Set<Node> preds) {
+        this.id = id;
+        this.label = label;
+        this.type = type;
+        this.uri = uri;
+        this.preds = preds;
+    }
+
+    public void addPredecessors(Set<Node> preds) {
+        this.preds.addAll(preds);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof Node n && this.id == n.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("id=%s,label='%s',type=%s", id, label, type);
+    }
+}

--- a/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
@@ -34,17 +34,22 @@ public class MermaidRenderer {
 
     private int indent;
 
+    private void reset() {
+        builder = new StringBuilder();
+        indent = 0;
+    }
+
     private void append(String format, Object... args) {
         builder.append("  ".repeat(indent));
         builder.append(String.format(format, args));
         builder.append('\n');
     }
 
-    public void incIndent() {
+    private void incIndent() {
         indent++;
     }
 
-    public void decIndent() {
+    private void decIndent() {
         indent--;
     }
 
@@ -56,9 +61,7 @@ public class MermaidRenderer {
         var outputs = graph.outputs.values();
 
         // render graph
-        builder = new StringBuilder();
-        indent = 0;
-
+        reset();
         append("flowchart TB");
         incIndent();
         append("subgraph %s", isEntry ? "\" \"" : name);

--- a/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
@@ -30,11 +30,20 @@ import java.util.stream.Stream;
  */
 public class MermaidRenderer {
 
-    private static final boolean SHOW_VARIABLES = false;
+    private static final List<String> VALID_DIRECTIONS = List.of("LR", "TB", "TD");
+
+    private final String direction;
+
+    private final boolean verbose;
 
     private StringBuilder builder;
 
     private int indent;
+
+    public MermaidRenderer(String direction, boolean verbose) {
+        this.direction = VALID_DIRECTIONS.contains(direction) ? direction : "TB";
+        this.verbose = verbose;
+    }
 
     private void reset() {
         builder = new StringBuilder();
@@ -64,7 +73,7 @@ public class MermaidRenderer {
 
         // render graph
         reset();
-        append("flowchart TB");
+        append("flowchart %s", direction);
         incIndent();
         append("subgraph %s", isEntry ? "\" \"" : name);
         incIndent();
@@ -183,7 +192,7 @@ public class MermaidRenderer {
     }
 
     private boolean isHidden(Node dn) {
-        return !SHOW_VARIABLES && dn.type == Node.Type.NAME;
+        return !verbose && dn.type == Node.Type.NAME;
     }
 
     private static String renderNode(int id, String label, Node.Type type) {

--- a/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
@@ -35,13 +35,14 @@ import groovy.lang.Tuple2;
  */
 public class MermaidRenderer {
 
-    private static boolean hideVariables = true;
-    private static boolean uniqueNames = false;
+    private final boolean hideVariables;
+    private final boolean uniqueNames;
     private Collection<Node> inputs = null;
     private Collection<Node> outputs = null;
 
-    public void toggleVariableHiding() {
-        hideVariables = !hideVariables;
+    public MermaidRenderer(boolean hideVariables) {
+        this.hideVariables = hideVariables;
+        this.uniqueNames = false;
     }
 
     public String render(String name, Graph graph) {
@@ -143,11 +144,11 @@ public class MermaidRenderer {
      * @param inputs
      * @param outputs
      */
-    private static boolean isHidden(Node dn, Collection<Node> inputs, Collection<Node> outputs) {
+    private boolean isHidden(Node dn, Collection<Node> inputs, Collection<Node> outputs) {
         return hideVariables && dn.type == Node.Type.NAME && !inputs.contains(dn) && !outputs.contains(dn);
     }
 
-    private static String renderNode(int id, String label, Node.Type type) {
+    private String renderNode(int id, String label, Node.Type type) {
         String name;
         if( uniqueNames ) {
             name = String.format("%s<%d>", label, id);

--- a/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
@@ -15,24 +15,20 @@
  */
 package nextflow.lsp.services.script.dag;
 
-import static org.codehaus.groovy.ast.tools.GeneralUtils.inSamePackage;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.function.Function;
 
-import org.eclipse.lsp4j.jsonrpc.messages.Tuple;
 
 import groovy.lang.Tuple2;
 
 /**
  *
  * @author Ben Sherman <bentshermann@gmail.com>
+ * @author Erik Danielsson <danielsson.erik.0@gmail.com>
  */
 public class MermaidRenderer {
 
@@ -57,7 +53,7 @@ public class MermaidRenderer {
         var nodes = graph.nodes.values();
         outputs = graph.outputs.values();
 
-        // Collapse graph
+        // Collapse graph i.e. remove nodes that shouldn't be part of the layout
         graph.collapseGraph(isHidden(inputs, outputs), isHiddenIfDisconnected());
 
         // render inputs
@@ -154,7 +150,7 @@ public class MermaidRenderer {
         case NAME -> String.format("v%d[\"%s\"]", id, name);
         case OPERATOR -> String.format("v%d([%s])", id, name);
         case CONDITIONAL -> String.format("v%d([conditional])", id);
-        case NULL -> String.format("v%d([null])", id);
+        case NULL -> String.format("v%d{null}", id);
         };
     }
 

--- a/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
@@ -149,7 +149,7 @@ public class MermaidRenderer {
 
         // render nodes
         for( var dn : subgraph.nodes ) {
-            if( dn.type == Node.Type.NAME )
+            if( isHidden(dn) )
                 continue;
 
             var label = dn.label

--- a/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
@@ -40,6 +40,10 @@ public class MermaidRenderer {
     private Collection<Node> inputs = null;
     private Collection<Node> outputs = null;
 
+    public void toggleVariableHiding() {
+        hideVariables = !hideVariables;
+    }
+
     public String render(String name, Graph graph) {
         var isEntry = name == null;
         var lines = new ArrayList<String>();
@@ -62,21 +66,6 @@ public class MermaidRenderer {
             lines.add("  end");
         }
 
-        // render nodes
-        // for (var dn : nodes) {
-        // if (isHidden(dn, inputs, outputs))
-        // continue;
-
-        // var label = dn.label
-        // .replaceAll("\n", "\\\\\n")
-        // .replaceAll("\"", "\\\\\"");
-
-        // lines.add(" " + renderNode(dn.id, label, dn.type));
-
-        // if (dn.uri != null)
-        // lines.add(String.format(" click v%d href \"%s\" _blank", dn.id,
-        // dn.uri.toString()));
-        // }
         var subgraphEdges = renderSubgraphs(graph.activeSubgraphs.peek(), lines, 0);
 
         // render outputs
@@ -169,8 +158,7 @@ public class MermaidRenderer {
         case NAME -> String.format("v%d[\"%s\"]", id, name);
         case OPERATOR -> String.format("v%d([%s])", id, name);
         case CONDITIONAL -> String.format("v%d([conditional])", id);
-        case IF -> String.format("v%d([if])", id);
-        case ELSE -> String.format("v%d([else])", id);
+        case NULL -> String.format("v%d([null])", id);
         };
     }
 

--- a/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/MermaidRenderer.java
@@ -15,8 +15,10 @@
  */
 package nextflow.lsp.services.script.dag;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,7 +30,7 @@ import java.util.stream.Stream;
  */
 public class MermaidRenderer {
 
-    private final boolean showVariables = false;
+    private static final boolean SHOW_VARIABLES = false;
 
     private StringBuilder builder;
 
@@ -81,7 +83,7 @@ public class MermaidRenderer {
         }
 
         // render nodes
-        var allSubgraphs = new HashSet<Subgraph>();
+        var allSubgraphs = new ArrayList<Subgraph>();
         renderSubgraph(graph.peekSubgraph(), allSubgraphs);
 
         // render outputs
@@ -121,8 +123,8 @@ public class MermaidRenderer {
 
         // render subgraph edges
         for( var subgraph : allSubgraphs ) {
-            for( var dnPred : subgraph.preds )
-                append("v%d --> s%d", dnPred.id, subgraph.id);
+            if( subgraph.pred != null )
+                append("v%d --> s%d", subgraph.pred.id, subgraph.id);
         }
 
         decIndent();
@@ -137,7 +139,7 @@ public class MermaidRenderer {
      * @param subgraph
      * @param allSubgraphs
      */
-    private void renderSubgraph(Subgraph subgraph, Set<Subgraph> allSubgraphs) {
+    private void renderSubgraph(Subgraph subgraph, List<Subgraph> allSubgraphs) {
         allSubgraphs.add(subgraph);
 
         if( subgraph.id > 0 ) {
@@ -181,7 +183,7 @@ public class MermaidRenderer {
     }
 
     private boolean isHidden(Node dn) {
-        return !showVariables && dn.type == Node.Type.NAME;
+        return !SHOW_VARIABLES && dn.type == Node.Type.NAME;
     }
 
     private static String renderNode(int id, String label, Node.Type type) {
@@ -191,10 +193,5 @@ public class MermaidRenderer {
             case CONTROL  -> String.format("v%d{ }", id);
         };
     }
-
-    private static record Edge(
-        int source,
-        int target
-    ) {}
 
 }

--- a/src/main/java/nextflow/lsp/services/script/dag/VariableContext.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/VariableContext.java
@@ -117,25 +117,15 @@ class VariableContext {
             if( variable.depth > currentDepth() )
                 return;
 
-            // merge symbols from else scope where applicable
+            // propagate symbols that are definitely assigned
             var other = elseScope.get(name);
             if( other != null )
-                variable = variable.union(other);
+                allSymbols.put(name, variable.union(other));
 
-            // NOTE (Erik 2025-08-01): if `other == null` then we should issue a compilation error
-            // since the variable is not declared in the else branch or preceding outside scope
-
-            allSymbols.put(name, variable);
+            // TODO: variables assigned in if but not else (or outside scope) are not definitely assigned
         });
 
-        // Add variables defined in the else branch but not in the if branch
-        // It is here we check that all variables declared in the else branch are declared in the if branch
-        elseScope.forEach((name, variable) -> {
-            if( variable.depth > currentDepth() || ifScope.containsKey(name) )
-                return; // The variable is local or declared in the if branch
-
-            allSymbols.put(name, variable); // NOTE (Erik 2025-08-01): replace this line an appropriate compilation error
-        });
+        // TODO: variables assigned in else but not if are not definitely assigned
 
         // add merged symbols to current scope
         scopes.peek().putAll(allSymbols);

--- a/src/main/java/nextflow/lsp/services/script/dag/VariableContext.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/VariableContext.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nextflow.lsp.services.script.dag;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ * @author Erik Danielsson <danielsson.erik.0@gmail.com>
+ */
+class VariableContext {
+
+    private Stack<Map<String,Variable>> scopes = new Stack<>();
+
+    public VariableContext() {
+        scopes.push(new HashMap<>());
+    }
+
+    /**
+     * Get the current scope.
+     */
+    public Map<String,Variable> peekScope() {
+        return scopes.peek();
+    }
+
+    /**
+     * Enter a new scope, inheriting all symbols defined
+     * in the parent scope.
+     */
+    public void pushScope() {
+        var newScope = new HashMap<String,Variable>();
+        scopes.peek().forEach((name, variable) -> {
+            newScope.put(name, variable.shallowCopy());
+        });
+        scopes.push(newScope);
+    }
+
+    /**
+     * Exit the current scope.
+     */
+    public Map<String,Variable> popScope() {
+        return scopes.pop();
+    }
+
+    /**
+     * Get the current predecessors for a given symbol.
+     *
+     * @param name
+     */
+    public Set<Node> getSymbol(String name) {
+        var scope = scopes.peek();
+        return scope.containsKey(name)
+            ? scope.get(name).preds
+            : Collections.emptySet();
+    }
+
+    /**
+     * Put a symbol into the current scope.
+     *
+     * @param name
+     * @param dn
+     * @param isLocal
+     */
+    public void putSymbol(String name, Node dn, boolean isLocal) {
+        var scope = scopes.peek();
+        if( scope.containsKey(name) ) {
+            // reassign variable if it is already defined
+            var variable = scope.get(name);
+            variable.preds.clear();
+            variable.preds.add(dn);
+        }
+        else {
+            var depth = isLocal ? currentDepth() : 1;
+            var preds = new HashSet<Node>();
+            preds.add(dn);
+            var variable = new Variable(depth, preds);
+            scope.put(name, variable);
+        }
+    }
+
+    public void putSymbol(String name, Node dn) {
+        putSymbol(name, dn, false);
+    }
+
+    /**
+     * Merge two conditional scopes into the current scope.
+     *
+     * @param ifScope
+     * @param elseScope
+     */
+    public void mergeConditionalScopes(Map<String,Variable> ifScope, Map<String,Variable> elseScope) {
+        var allSymbols = new HashMap<String,Variable>();
+
+        // add symbols from if branch
+        ifScope.forEach((name, variable) -> {
+            if( variable.depth > currentDepth() )
+                return;
+
+            var other = elseScope.get(name);
+            if( other != null )
+                variable = variable.union(other);
+
+            if( allSymbols.containsKey(name) )
+                allSymbols.put(name, allSymbols.get(name).union(variable));
+            else
+                allSymbols.put(name, variable.shallowCopy());
+        });
+
+        // add remaining symbols from else branch
+        elseScope.forEach((name, variable) -> {
+            if( variable.depth > currentDepth() )
+                return;
+
+            if( !allSymbols.containsKey(name) )
+                allSymbols.put(name, variable.shallowCopy());
+        });
+
+        // add merged symbols to current scope
+        scopes.peek().putAll(allSymbols);
+    }
+
+    private int currentDepth() {
+        return scopes.size();
+    }
+
+}
+
+
+class Variable {
+
+    public final int depth;
+
+    public final Set<Node> preds;
+
+    Variable(int depth, Set<Node> preds) {
+        this.depth = depth;
+        this.preds = preds;
+    }
+
+    public Variable shallowCopy() {
+        return new Variable(depth, new HashSet<Node>(preds));
+    }
+
+    public Variable union(Variable other) {
+        var allPreds = new HashSet<Node>(preds);
+        allPreds.addAll(other.preds);
+        return new Variable(depth, allPreds);
+    }
+}

--- a/src/main/java/nextflow/lsp/services/script/dag/VariableContext.java
+++ b/src/main/java/nextflow/lsp/services/script/dag/VariableContext.java
@@ -122,7 +122,19 @@ class VariableContext {
             if( other != null )
                 variable = variable.union(other);
 
+            // NOTE (Erik 2025-08-01): if `other == null` then we should issue a compilation error
+            // since the variable is not declared in the else branch or preceding outside scope
+
             allSymbols.put(name, variable);
+        });
+
+        // Add variables defined in the else branch but not in the if branch
+        // It is here we check that all variables declared in the else branch are declared in the if branch
+        elseScope.forEach((name, variable) -> {
+            if( variable.depth > currentDepth() || ifScope.containsKey(name) )
+                return; // The variable is local or declared in the if branch
+
+            allSymbols.put(name, variable); // NOTE (Erik 2025-08-01): replace this line an appropriate compilation error
         });
 
         // add merged symbols to current scope

--- a/src/test/groovy/nextflow/lsp/services/script/dag/PreviewDagTest.groovy
+++ b/src/test/groovy/nextflow/lsp/services/script/dag/PreviewDagTest.groovy
@@ -35,7 +35,7 @@ class PreviewDagTest extends Specification {
         return true
     }
 
-    def 'should render the DAG preview for a workflow' () {
+    def 'should handle an if-else statement' () {
         given:
         def service = getScriptService()
         def uri = getUri('main.nf')
@@ -93,6 +93,69 @@ class PreviewDagTest extends Specification {
                 v0 --> v2
                 v2 --> v7
                 v4 --> v7
+                v1 --> s1
+                v1 --> s2
+              end
+            """
+        )
+    }
+
+    def 'should handle a ternary expression' () {
+        given:
+        def service = getScriptService()
+        def uri = getUri('main.nf')
+
+        expect:
+        checkDagPreview(service, uri,
+            '''\
+            workflow {
+                echo = params.echo
+                    ? TOUCH(params.echo)
+                    : DEFAULT()
+                APPEND(echo)
+            }
+
+            process TOUCH {
+                input:
+                val x
+
+                script:
+                true
+            }
+
+            process DEFAULT {
+                true
+            }
+
+            process APPEND {
+                input:
+                val x
+
+                script:
+                true
+            }
+            ''',
+            """\
+            flowchart TB
+              subgraph " "
+                subgraph params
+                  v0["echo"]
+                end
+                v1{ }
+                v5([APPEND])
+                click v5 href "$uri" _blank
+                subgraph s1[" "]
+                  v2([TOUCH])
+                  click v2 href "$uri" _blank
+                end
+                subgraph s2[" "]
+                  v3([DEFAULT])
+                  click v3 href "$uri" _blank
+                end
+                v0 --> v1
+                v0 --> v2
+                v2 --> v5
+                v3 --> v5
                 v1 --> s1
                 v1 --> s2
               end

--- a/src/test/groovy/nextflow/lsp/services/script/dag/PreviewDagTest.groovy
+++ b/src/test/groovy/nextflow/lsp/services/script/dag/PreviewDagTest.groovy
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.lsp.services.script.dag
+
+import nextflow.lsp.services.script.ScriptService
+import spock.lang.Specification
+
+import static nextflow.lsp.TestUtils.*
+import static nextflow.lsp.util.JsonUtils.*
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+class PreviewDagTest extends Specification {
+
+    boolean checkDagPreview(ScriptService service, String uri, String source, String mmd) {
+        open(service, uri, source.stripIndent())
+        def response = service.executeCommand('nextflow.server.previewDag', [asJson(uri), asJson(null)])
+        assert response.result == mmd.stripIndent()
+        return true
+    }
+
+    def 'should render the DAG preview for a workflow' () {
+        given:
+        def service = getScriptService()
+        def uri = getUri('main.nf')
+
+        expect:
+        checkDagPreview(service, uri,
+            '''\
+            workflow {
+                if (params.echo) {
+                    echo = TOUCH(params.echo)
+                } else {
+                    echo = DEFAULT()
+                }
+                APPEND(echo)
+            }
+
+            process TOUCH {
+                input:
+                val x
+
+                script:
+                true
+            }
+
+            process DEFAULT {
+                true
+            }
+
+            process APPEND {
+                input:
+                val x
+
+                script:
+                true
+            }
+            ''',
+            """\
+            flowchart TB
+              subgraph " "
+                subgraph params
+                  v0["echo"]
+                end
+                v1{ }
+                v7([APPEND])
+                click v7 href "$uri" _blank
+                subgraph s1[" "]
+                  v2([TOUCH])
+                  click v2 href "$uri" _blank
+                end
+                subgraph s2[" "]
+                  v4([DEFAULT])
+                  click v4 href "$uri" _blank
+                end
+                v0 --> v1
+                v0 --> v2
+                v2 --> v7
+                v4 --> v7
+                v1 --> s1
+                v1 --> s2
+              end
+            """
+        )
+    }
+
+    def 'should handle variable reassignment in an if statement' () {
+        given:
+        def service = getScriptService()
+        def uri = getUri('main.nf')
+
+        expect:
+        checkDagPreview(service, uri,
+            '''\
+            workflow {
+                main:
+                ch_versions = channel.empty()
+
+                FOO()
+                ch_versions = ch_versions.mix( FOO.out.versions )
+
+                if (params.bar) {
+                    BAR()
+                    ch_versions = ch_versions.mix( BAR.out.versions )
+                }
+
+                publish:
+                versions = ch_versions
+            }
+
+            process FOO {
+                output:
+                val 'versions', emit: versions
+
+                script:
+                true
+            }
+
+            process BAR {
+                output:
+                val 'versions', emit: versions
+
+                script:
+                true
+            }
+            ''',
+            """\
+            flowchart TB
+              subgraph " "
+                subgraph params
+                  v3["bar"]
+                end
+                v1([FOO])
+                click v1 href "$uri" _blank
+                v4{ }
+                subgraph s1[" "]
+                  v5([BAR])
+                  click v5 href "$uri" _blank
+                end
+                subgraph publish
+                  v8["versions"]
+                end
+                v3 --> v4
+                v1 --> v8
+                v5 --> v8
+                v4 --> s1
+              end
+            """
+        )
+    }
+
+}

--- a/src/test/groovy/nextflow/lsp/services/script/dag/PreviewDagTest.groovy
+++ b/src/test/groovy/nextflow/lsp/services/script/dag/PreviewDagTest.groovy
@@ -99,6 +99,55 @@ class PreviewDagTest extends Specification {
               end
             """
         )
+
+        checkDagPreview(service, uri, null,
+            '''\
+            workflow {
+                main:
+                if (TEST(params.input)) {
+                    intermed = 1
+                } else {
+                    intermed = 2
+                }
+                publish:
+                result = APPLY(intermed)
+            }
+
+            process TEST {
+                input:
+                val x
+
+                script:
+                true
+            }
+
+            process APPLY {
+                input:
+                val x
+
+                script:
+                true
+            }
+            ''',
+            """\
+            flowchart TB
+              subgraph " "
+                subgraph params
+                  v0["input"]
+                end
+                v1([TEST])
+                click v1 href "$uri" _blank
+                v6([APPLY])
+                click v6 href "$uri" _blank
+                subgraph publish
+                  v7["result"]
+                end
+                v0 --> v1
+                v1 --> v6
+                v6 --> v7
+              end
+            """
+        )
     }
 
     def 'should collapse empty if-else statement' () {

--- a/src/test/groovy/nextflow/lsp/services/script/dag/PreviewDagTest.groovy
+++ b/src/test/groovy/nextflow/lsp/services/script/dag/PreviewDagTest.groovy
@@ -16,6 +16,7 @@
 
 package nextflow.lsp.services.script.dag
 
+import nextflow.lsp.services.LanguageServerConfiguration
 import nextflow.lsp.services.script.ScriptService
 import spock.lang.Specification
 
@@ -30,7 +31,7 @@ class PreviewDagTest extends Specification {
 
     boolean checkDagPreview(ScriptService service, String uri, String source, String mmd) {
         open(service, uri, source.stripIndent())
-        def response = service.executeCommand('nextflow.server.previewDag', [asJson(uri), asJson(null)])
+        def response = service.executeCommand('nextflow.server.previewDag', [asJson(uri), asJson(null)], LanguageServerConfiguration.defaults())
         assert response.result == mmd.stripIndent()
         return true
     }


### PR DESCRIPTION
This PR makes quite substantial changes to the DAG preview feature of the language server. First and foremost it adds support for rendering control flow correctly (issues #93 #88). 

The solution to these issues is to use scoped symbol tables where each name in the program can correspond to several nodes in the control flow DAG. As we enter a new conditional statement each of the two branches inherits the symbols from the outer scope. Once we leave the conditional statement the symbol table for the outer scope is the union of the symbol table for each branch, minus any local variables declared. 

To have separate plates for separate branches I have also added subgraphs for each conditional branch. The conditional node (corresponding to the boolean in the if) is always a predecessor. Since an a conditional branch can contain a conditional branch, the subgraphs are represented as a tree structure and rendered accordingly.

**Example**: if we call the symbol table `s`  then we have the following
```nextflow
workflow {
    test  = params.echo // s = {'test': {<Node>("test", ...) , 0)>}
    if (test) {
        echo = TOUCH(params.echo) // s = {'test': {<Node(params.echo, 0)>, 'echo': {<Node('echo', 1)>}
    } else {
        echo = DEFAULT() // s = {'test': {<Node(params.echo, 0)>, 'echo': {<Node('echo', 2)>}
    }
    // s = {'test': {<Node(params.echo, 0)>, 'echo': {<Node('echo', 1)>, <Node('echo', 2)>}
   // Overwrite test variable
    test  = APPEND(echo) // s = {'test': {<Node(params.echo, 1)>, 'echo': {<Node('echo', 1)>, <Node('echo', 2)>}
}
```
which will be rendered as the DAG
```mermaid
flowchart TB
subgraph " "
  subgraph params
    v0["echo"]
  end
  v0["echo"]
  v2([conditional])
  v7([APPEND])
  subgraph s1[" "]
    v3([TOUCH])
  end
  subgraph s2[" "]
    v5([DEFAULT])
  end
    v0 --> v2
    v0 --> v3
    v3 --> v7
    v5 --> v7
    v2 --> s2
    v2 --> s1
end
```

If a global variable is assigned in one branch but not the other then it is implicitly initialized with `null`. To address this, we check before entering the outside scope whether this was the case and add a `null` node to the scope where the variable is not declared.
This means that the code: 
```nextflow
workflow {
    if (params.echo) {
        echo = TOUCH(params.echo)
    } 
    APPEND(echo) 
}
```
which will be rendered as 
```mermaid
flowchart TB
subgraph " "
  subgraph params
    v0["echo"]
  end
  v0["echo"]
  v1([conditional])
  v4{null}
  v6([APPEND])
  subgraph s1[" "]
    v2([TOUCH])
  end
    v0 --> v1
    v0 --> v2
    v2 --> v6
    v4 --> v6
    v1 --> s1
end
```
## Removing nodes that shouldn't be rendered
By default we only want to render inputs, processes/(sub)workflows and outputs. This means that we need to collapse the rest of the graph. There are two types of nodes we remove:

- Variable nodes
- Disconnected null nodes

The second case is new and correspond to the situation where a variable is is initalized in one branch but never used outside the branch, which will create a disconnected null in the other branch. We remove nodes in place via a DFS in the `Graph.collapseGraph` function to which we pass predicates for nodes that should _always_ be hidden (variable nodes) and nodes that should be hidden if they become disconnected (null nodes). 

## Configuration support for rendering variable nodes
I have also added the configuration option `nextflow.dag.showVariables` which toggles whether variables should be shown (or if the graph should be collapsed). It is `false` by default. I added it since it could be (was for me) useful for debugging purposes.

If this is not desired we can revert the changes in `287324c`. [Here](https://github.com/nextflow-io/vscode-language-nextflow/pull/148) is the corresponding PR on the `vscode-code-language` side.



