### PR TITLE
Formatting tests: print git style diff between formatter output and expected output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
   testImplementation ('org.objenesis:objenesis:3.4')
   testImplementation ('net.bytebuddy:byte-buddy:1.14.17')
   testImplementation ('org.spockframework:spock-core:2.3-groovy-4.0') { exclude group: 'org.apache.groovy' }
+  testImplementation ("io.github.java-diff-utils:java-diff-utils:4.12")
 }
 
 application {

--- a/src/test/groovy/nextflow/lsp/services/script/ScriptFormattingTest.groovy
+++ b/src/test/groovy/nextflow/lsp/services/script/ScriptFormattingTest.groovy
@@ -18,6 +18,8 @@ package nextflow.lsp.services.script
 
 import nextflow.script.formatter.FormattingOptions
 import spock.lang.Specification
+import com.github.difflib.text.*;
+import java.util.stream.Collectors;
 
 import static nextflow.lsp.TestUtils.*
 
@@ -25,15 +27,80 @@ import static nextflow.lsp.TestUtils.*
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
+
+
+
 class ScriptFormattingTest extends Specification {
+
+    enum Color {
+        RESET("\033[0m"),       // Reset
+        RED("\033[1;31m"),      // Red
+        GREEN("\033[1;32m"),    // Green
+
+        BLACK("\033[1;30m");   // BLACK
+
+        private final String code;
+
+        Color(String code) {
+            this.code = code;
+        }
+
+        @Override
+        public String toString() {
+            return code;
+        }
+    }
 
     boolean checkFormat(ScriptService service, String uri, String before, String after) {
         open(service, uri, before)
         def textEdits = service.formatting(URI.create(uri), new FormattingOptions(4, true))
-        return textEdits.first().getNewText() == after.stripIndent()
+        def actualText
+        if (textEdits.size() > 0) {
+            actualText = textEdits.first().getNewText()
+        } else {
+            actualText = "No text at all"
+        }
+        def expectedText = after.stripIndent()
+        System.err.println("Input text:\n" + before)
+        // Create a configured DiffRowGenerator
+        DiffRowGenerator generator = DiffRowGenerator.create()
+                        //  .showInlineDiffs(true)
+                        // // .mergeOriginalRevised(true)
+                        //  .inlineDiffByWord(true)
+                        // .oldTag(f -> Color.RED.toString())      //introduce markdown style for strikethrough
+                        // .newTag(f -> Color.GREEN.toString())     //introduce markdown style for bold
+                        .build();
+
+        // Compute the differences for two test texts.
+        List<DiffRow> rows = generator.generateDiffRows(
+            expectedText.lines().collect(Collectors.toList()),
+            actualText.lines().collect(Collectors.toList())
+        );
+        boolean success  = actualText == expectedText
+
+        System.err.println("\nDiff comparision between expected and actual");
+        for (DiffRow row : rows) {
+            DiffRow.Tag tag = row.getTag();
+            if (tag ==  DiffRow.Tag.INSERT) {
+                System.err.println(Color.GREEN.toString() + "++: " + row.getNewLine() + Color.RESET.toString());
+            } else if (tag ==  DiffRow.Tag.DELETE) {
+                System.err.println(Color.RED.toString() + "--: " + row.getOldLine() + Color.RESET.toString());
+            } else if (tag ==  DiffRow.Tag.CHANGE) {
+                System.err.println(Color.GREEN.toString() + "++: " + row.getNewLine() + Color.RESET.toString());
+                System.err.println(Color.RED.toString() + "--: " + row.getOldLine() + Color.RESET.toString());
+            } else {
+                System.err.println(Color.BLACK.toString() + "  : " + row.getOldLine() + Color.RESET.toString());
+            }
+        }
+        if (rows.stream().allMatch(r -> r.getTag() == DiffRow.Tag.EQUAL)) {
+            System.err.println(String.format("No diff! Comparison yields %s%b%s\n",
+                (success ? Color.GREEN : Color.RED), success, Color.RESET)
+            );
+        }
+        return actualText == expectedText
     }
 
-    def 'should format a script' () {
+    def 'should format leading comment' () {
         given:
         def service = getScriptService()
         def uri = getUri('main.nf')

--- a/src/test/groovy/nextflow/lsp/services/script/ScriptFormattingTest.groovy
+++ b/src/test/groovy/nextflow/lsp/services/script/ScriptFormattingTest.groovy
@@ -27,16 +27,12 @@ import static nextflow.lsp.TestUtils.*
  *
  * @author Ben Sherman <bentshermann@gmail.com>
  */
-
-
-
 class ScriptFormattingTest extends Specification {
 
     enum Color {
         RESET("\033[0m"),       // Reset
         RED("\033[1;31m"),      // Red
         GREEN("\033[1;32m"),    // Green
-
         BLACK("\033[1;30m");   // BLACK
 
         private final String code;
@@ -62,14 +58,9 @@ class ScriptFormattingTest extends Specification {
         }
         def expectedText = after.stripIndent()
         System.err.println("Input text:\n" + before)
+
         // Create a configured DiffRowGenerator
-        DiffRowGenerator generator = DiffRowGenerator.create()
-                        //  .showInlineDiffs(true)
-                        // // .mergeOriginalRevised(true)
-                        //  .inlineDiffByWord(true)
-                        // .oldTag(f -> Color.RED.toString())      //introduce markdown style for strikethrough
-                        // .newTag(f -> Color.GREEN.toString())     //introduce markdown style for bold
-                        .build();
+        DiffRowGenerator generator = DiffRowGenerator.create().build();
 
         // Compute the differences for two test texts.
         List<DiffRow> rows = generator.generateDiffRows(
@@ -100,7 +91,7 @@ class ScriptFormattingTest extends Specification {
         return actualText == expectedText
     }
 
-    def 'should format leading comment' () {
+    def 'should format a script' () {
         given:
         def service = getScriptService()
         def uri = getUri('main.nf')


### PR DESCRIPTION
Add git style diff between expected output and actual formatter output. I've added the package `java-diff-utils` to the dependencies, which seems to be well maintained. The printer uses ANSI color codes for rendering -- there might very well be a cleaner way of printing output with colors in Java.