### PR TITLE
Add workspace indexing progress notifications

### DIFF
--- a/src/test/groovy/nextflow/lsp/TestLanguageClient.groovy
+++ b/src/test/groovy/nextflow/lsp/TestLanguageClient.groovy
@@ -20,8 +20,10 @@ import java.util.concurrent.CompletableFuture
 
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.ProgressParams
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.ShowMessageRequestParams
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams
 import org.eclipse.lsp4j.services.LanguageClient
 
 /**
@@ -50,5 +52,15 @@ class TestLanguageClient implements LanguageClient {
     @Override
     public void logMessage(MessageParams message) {
         System.err.println(message.getMessage())
+    }
+
+    @Override
+    public CompletableFuture<Void> createProgress(WorkDoneProgressCreateParams params) {
+        return CompletableFuture.completedFuture(null)
+    }
+
+    @Override
+    public void notifyProgress(ProgressParams params) {
+        // No-op for tests
     }
 }


### PR DESCRIPTION
## Summary

Implements LSP `$/progress` notifications during workspace file indexing to provide visual feedback in editors/clients (fixes #148).

Written by Claude 🤖 

## Changes

- Add `BiConsumer<Integer, Integer>` progress callback parameter to `ASTNodeCache.update()`
- Report per-file progress using `AtomicInteger` for thread-safe counting in parallel stream
- Create `ProgressNotification` in `LanguageService.update0()` when indexing > 1 file
- Works for both initial workspace scan and batch file updates
- Uses workspace-specific token (`indexing-{rootUri.hashCode()}`) to support multiple workspaces

<details>

## Progress Flow Example

For a workspace with 60 files:

```
→ window/workDoneProgress/create { token: "indexing-12345678" }
← $/progress { token: "...", value: { kind: "begin", message: "Indexing 60 files...", percentage: 0 } }
← $/progress { token: "...", value: { kind: "report", message: "Indexing: 1 / 60 files", percentage: 1 } }
← $/progress { token: "...", value: { kind: "report", message: "Indexing: 2 / 60 files", percentage: 3 } }
...
← $/progress { token: "...", value: { kind: "report", message: "Indexing: 60 / 60 files", percentage: 100 } }
← $/progress { token: "...", value: { kind: "end" } }
```

## Testing

- [ ] Progress notifications only appear when indexing more than 1 file
- [ ] Progress is reported per-file for accurate progress bars in clients
- [ ] `finally` block ensures `progress.end()` is always called even if exceptions occur

</details>