### PR TITLE
Fix NPE related to missing a title for initialization

### DIFF
--- a/src/main/java/nextflow/lsp/NextflowLanguageServer.java
+++ b/src/main/java/nextflow/lsp/NextflowLanguageServer.java
@@ -489,7 +489,7 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
     private void initializeWorkspaces() {
         var progress = new ProgressNotification(client, "initialize");
         progress.create();
-        progress.begin("Initializing workspace...");
+        progress.begin("Initializing", "Initializing workspace...");
 
         var count = 0;
         var total = workspaceRoots.keySet().size() - 1;

--- a/src/main/java/nextflow/lsp/util/ProgressNotification.java
+++ b/src/main/java/nextflow/lsp/util/ProgressNotification.java
@@ -42,8 +42,9 @@ public class ProgressNotification {
         client.createProgress(new WorkDoneProgressCreateParams(Either.forLeft(token)));
     }
 
-    public void begin(String message) {
+    public void begin(String title, String message) {
         var progress = new WorkDoneProgressBegin();
+        progress.setTitle(title);
         progress.setMessage(message);
         progress.setPercentage(0);
         client.notifyProgress(new ProgressParams(Either.forLeft(token), Either.forLeft(progress)));


### PR DESCRIPTION
Currently, the title for WorkProgressBegin is not set. It is a required field in LSP4J and has caused unresolvable NPEs when developing an extension that uses this LSP. 