### PR TITLE
fix: normalize missing names in workspaceFolder responses

### DIFF
--- a/src/main/java/nextflow/lsp/NextflowLanguageServer.java
+++ b/src/main/java/nextflow/lsp/NextflowLanguageServer.java
@@ -137,7 +137,7 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
             for( var workspaceFolder : workspaceFolders ) {
                 var name = workspaceFolder.getName();
                 var uri = workspaceFolder.getUri();
-                addWorkspaceFolder(name, uri);
+                addWorkspaceFolder(normaliseWorkspaceFolderName(name, uri), uri);
             }
         }
 
@@ -518,6 +518,7 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
         for( var workspaceFolder : event.getRemoved() ) {
             var name = workspaceFolder.getName();
             log.debug("workspace/didChangeWorkspaceFolders remove " + name);
+            name = normaliseWorkspaceFolderName(name, workspaceFolder.getUri());
             workspaceRoots.remove(name);
             configServices.remove(name).clearDiagnostics();
             scriptServices.remove(name).clearDiagnostics();
@@ -526,6 +527,7 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
             var name = workspaceFolder.getName();
             var uri = workspaceFolder.getUri();
             log.debug("workspace/didChangeWorkspaceFolders add " + name + " " + uri);
+            name = normaliseWorkspaceFolderName(name, uri);
             addWorkspaceFolder(name, uri);
             configServices.get(name).initialize(configuration);
             scriptServices.get(name).initialize(configuration, configServices.get(name).getPluginSpecCache());
@@ -627,6 +629,14 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
         var scriptService = new ScriptService(uri);
         scriptService.connect(client);
         scriptServices.put(name, scriptService);
+    }
+
+    private static String normaliseWorkspaceFolderName(String name, String uri) {
+        if( name == null || !name.isEmpty() || uri == null )
+            return name;
+
+        var path = Path.of(URI.create(uri)).getFileName();
+        return path != null ? path.toString() : name;
     }
 
     private String relativePath(String uri) {

--- a/src/main/java/nextflow/lsp/NextflowLanguageServer.java
+++ b/src/main/java/nextflow/lsp/NextflowLanguageServer.java
@@ -88,6 +88,7 @@ import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceFoldersOptions;
 import org.eclipse.lsp4j.WorkspaceServerCapabilities;
 import org.eclipse.lsp4j.WorkspaceSymbol;
@@ -135,9 +136,9 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
         var workspaceFolders = params.getWorkspaceFolders();
         if( workspaceFolders != null && !workspaceFolders.isEmpty() ) {
             for( var workspaceFolder : workspaceFolders ) {
-                var name = workspaceFolder.getName();
+                var name = workspaceFolderName(workspaceFolder);
                 var uri = workspaceFolder.getUri();
-                addWorkspaceFolder(normaliseWorkspaceFolderName(name, uri), uri);
+                addWorkspaceFolder(name, uri);
             }
         }
 
@@ -516,18 +517,16 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
     public void didChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams params) {
         var event = params.getEvent();
         for( var workspaceFolder : event.getRemoved() ) {
-            var name = workspaceFolder.getName();
+            var name = workspaceFolderName(workspaceFolder);
             log.debug("workspace/didChangeWorkspaceFolders remove " + name);
-            name = normaliseWorkspaceFolderName(name, workspaceFolder.getUri());
             workspaceRoots.remove(name);
             configServices.remove(name).clearDiagnostics();
             scriptServices.remove(name).clearDiagnostics();
         }
         for( var workspaceFolder : event.getAdded() ) {
-            var name = workspaceFolder.getName();
+            var name = workspaceFolderName(workspaceFolder);
             var uri = workspaceFolder.getUri();
             log.debug("workspace/didChangeWorkspaceFolders add " + name + " " + uri);
-            name = normaliseWorkspaceFolderName(name, uri);
             addWorkspaceFolder(name, uri);
             configServices.get(name).initialize(configuration);
             scriptServices.get(name).initialize(configuration, configServices.get(name).getPluginSpecCache());
@@ -631,7 +630,9 @@ public class NextflowLanguageServer implements LanguageServer, LanguageClientAwa
         scriptServices.put(name, scriptService);
     }
 
-    private static String normaliseWorkspaceFolderName(String name, String uri) {
+    private static String workspaceFolderName(WorkspaceFolder workspaceFolder) {
+        var name = workspaceFolder.getName();
+        var uri = workspaceFolder.getUri();
         if( name == null || !name.isEmpty() || uri == null )
             return name;
 


### PR DESCRIPTION
Small PR that addresses the issue described in (https://github.com/nextflow-io/language-server/issues/122#issuecomment-4451957602)

workspaceFolder names are now normalised before use so that if they are empty, they are populated from the URI file name before use.

e.g
```
"workspaceFolders": [
  {
    "name": "",
    "uri": "file:///path/to/project/test"
  }
]
```

becomes

```
"workspaceFolders": [
  {
    "name": "test",
    "uri": "file:///path/to/project/test"
  }
]
```

This fixes Zed integration where certain workspace features were disabled as zed sends `""` as workspace names.

While doing this I realised it may be better to rework workspaceFolder handling to teat URIs as workspace identifiers instead of names. My Java is a bit rusty though - so haven't attempted that here.

No worries if you'd prefer not to merge this in favour of a more robust fix, but it's working for me with Zed using a locally built langauge server, so will leave it up in case it's useful to anyone else in the meantime.