### PR TITLE
Re-check consumer scripts when an included module changes (#165)

### DIFF
--- a/src/main/java/nextflow/lsp/ast/ASTNodeCache.java
+++ b/src/main/java/nextflow/lsp/ast/ASTNodeCache.java
@@ -88,6 +88,10 @@ public abstract class ASTNodeCache {
      * @param fileCache
      */
     public Set<URI> update(Set<URI> uris, FileCache fileCache) {
+        // expand the invalidation set to include dependents (e.g. files that
+        // include a changed module) so their cached analysis is recomputed
+        uris = expandInvalidation(uris);
+
         // invalidate cache for each source file
         for( var uri : uris ) {
             var nodes = nodesByURI.remove(uri);
@@ -156,6 +160,17 @@ public abstract class ASTNodeCache {
         result.addAll(uris);
         result.addAll(changedUris);
         return result;
+    }
+
+    /**
+     * Expand a set of changed files to include any cached files whose analysis
+     * depends on them (e.g. files that include a changed module). The default
+     * implementation returns the set unchanged.
+     *
+     * @param uris
+     */
+    protected Set<URI> expandInvalidation(Set<URI> uris) {
+        return uris;
     }
 
     /**

--- a/src/main/java/nextflow/lsp/services/script/ScriptAstCache.java
+++ b/src/main/java/nextflow/lsp/services/script/ScriptAstCache.java
@@ -18,8 +18,10 @@ package nextflow.lsp.services.script;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -155,6 +157,40 @@ public class ScriptAstCache extends ASTNodeCache {
         }
 
         return changedUris;
+    }
+
+    /**
+     * Expand a set of changed files to include every cached file that
+     * (transitively) includes one of them. Those consumers must be re-parsed
+     * so that their cross-file inferred types (e.g. a process's record output)
+     * are recomputed from fresh AST nodes rather than stale cached metadata.
+     *
+     * @param uris
+     */
+    @Override
+    protected Set<URI> expandInvalidation(Set<URI> uris) {
+        // reverse include graph: module uri -> files that include it
+        var dependents = new HashMap<URI, Set<URI>>();
+        for( var uri : getUris() ) {
+            for( var include : getIncludeNodes(uri) ) {
+                var depUri = localIncludeUri(uri, include.source.getText());
+                if( depUri != null )
+                    dependents.computeIfAbsent(depUri, (k) -> new HashSet<>()).add(uri);
+            }
+        }
+        if( dependents.isEmpty() )
+            return uris;
+
+        var result = new HashSet<>(uris);
+        var queue = new ArrayDeque<>(uris);
+        while( !queue.isEmpty() ) {
+            var uri = queue.poll();
+            for( var consumer : dependents.getOrDefault(uri, Collections.emptySet()) ) {
+                if( result.add(consumer) )
+                    queue.add(consumer);
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/test/groovy/nextflow/lsp/services/script/ScriptDiagnosticsTest.groovy
+++ b/src/test/groovy/nextflow/lsp/services/script/ScriptDiagnosticsTest.groovy
@@ -144,6 +144,79 @@ class ScriptDiagnosticsTest extends Specification {
         diagnostics.findAll { it.message.contains('is not compatible with process input') } == []
     }
 
+    def 'should re-check a consumer when an included module changes' () {
+        given:
+        def client = new TestLanguageClient()
+        def service = getScriptService(client)
+        def mainUri = getUri('workflow.nf')
+        def producerUri = getUri('producer.nf')
+        def consumerUri = getUri('consumer.nf')
+
+        def producer = { String outputExtra -> """\
+            nextflow.enable.types = true
+
+            process PRODUCER {
+                input:
+                record(id: String)
+
+                output:
+                record(id: id${outputExtra})
+
+                script:
+                \"\"\"
+                echo hello > data.txt
+                \"\"\"
+            }
+            """ }
+        def consumer = '''\
+            nextflow.enable.types = true
+
+            process CONSUMER {
+                input:
+                record(id: String, data: Path)
+
+                output:
+                record(id: id)
+
+                script:
+                """
+                cat ${data}
+                """
+            }
+            '''
+        def main = '''\
+            nextflow.enable.types = true
+
+            include { PRODUCER } from './producer.nf'
+            include { CONSUMER } from './consumer.nf'
+
+            workflow {
+                ch_produced = PRODUCER(channel.of(record(id: 'sample1')))
+                CONSUMER(ch_produced)
+            }
+            '''
+
+        when: 'producer emits a compatible record { id, data }'
+        open(service, producerUri, producer(", data: file('data.txt')"))
+        open(service, consumerUri, consumer)
+        open(service, mainUri, main)
+        service.updateNow()
+        then:
+        client.getDiagnostics(mainUri).findAll { it.message.contains('is not compatible with process input') } == []
+
+        when: 'only the producer module is edited to emit an incompatible record { id }'
+        open(service, producerUri, producer(''))
+        service.updateNow()
+        then: 'the consumer call is re-checked and now reports the mismatch'
+        client.getDiagnostics(mainUri).findAll { it.message.contains('is not compatible with process input') }.size() == 1
+
+        when: 'the producer module is restored'
+        open(service, producerUri, producer(", data: file('data.txt')"))
+        service.updateNow()
+        then: 'the stale warning is cleared'
+        client.getDiagnostics(mainUri).findAll { it.message.contains('is not compatible with process input') } == []
+    }
+
     def 'should clear diagnostics when an error is fixed' () {
         given:
         def client = new TestLanguageClient()


### PR DESCRIPTION
## Overview

Follow-up to b29edb8 for #165. That commit fixed the cold-scan false warning by type-checking included modules before their includers. This addresses the remaining incremental-invalidation half of the issue:

> Editing a module does not re-check its consumers, so a stale false warning lingers in the editor until the consuming file is touched.

## Root cause

Editing a module *did* add its direct consumer to the change set, so the consumer was re-type-checked — but only the directly-changed files are re-parsed. Consumers pulled in during analysis were re-type-checked over their **old AST nodes**, which still carried `INFERRED_TYPE` metadata from the previous run. Since `getType()` short-circuits on cached `INFERRED_TYPE`, a changed process output type was never observed (e.g. `ch_produced` kept resolving to the stale `Channel<Record{id, data}>`). Transitive consumers (`A → B → C`) were never re-checked at all.

## Fix

Add an `expandInvalidation()` hook in `ASTNodeCache.update()` (default no-op) that runs *before* parsing. `ScriptAstCache` overrides it to walk the reverse include graph and pull every transitive consumer into the invalidation set, so consumers are re-parsed from fresh (metadata-free) AST nodes and their cross-file inferred types are recomputed. Reuses the existing parse→analyze pipeline and the `localIncludeUri` helper.

## Testing

New test in `ScriptDiagnosticsTest`: with a compatible producer→consumer wiring, edit **only** the producer module to emit an incompatible record → the consumer call now reports the mismatch; restore the producer → the stale warning clears. Verified it fails without the fix and passes with it. Full suite green.

## Known ceiling

`expandInvalidation` rebuilds the reverse graph each update and `localIncludeUri` does one `Files.isDirectory` stat per include — fine at debounced-update cadence; memoize if it shows up on a large workspace. Remote/plugin includes are still not tracked.