### PR TITLE
Remove undeclared dependencies from Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,11 @@ configurations {
 dependencies {
   implementation 'io.nextflow:nf-lang:26.04.6'
   implementation 'org.apache.groovy:groovy:4.0.31'
+  implementation 'org.apache.groovy:groovy-ant:4.0.31'
+  implementation 'org.apache.groovy:groovy-astbuilder:4.0.31'
+  implementation 'org.apache.groovy:groovy-datetime:4.0.31'
+  implementation 'org.apache.groovy:groovy-dateutil:4.0.31'
+  implementation 'org.apache.groovy:groovy-groovydoc:4.0.31'
   implementation 'org.apache.groovy:groovy-json:4.0.31'
   implementation 'org.apache.groovy:groovy-yaml:4.0.31'
   implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.0'

--- a/build.gradle
+++ b/build.gradle
@@ -30,17 +30,22 @@ test {
 }
 
 configurations {
+  groovyCompiler
   nextflowRuntime
 }
 
+// Pin the Groovy compiler classpath: the Groovy plugin otherwise infers a full
+// groovy-all classpath, dragging in Ant (groovy-ant) and javaparser/qdox
+// (groovy-groovydoc), none of which this build uses
+tasks.withType(GroovyCompile).configureEach {
+  groovyClasspath = configurations.groovyCompiler
+}
+
 dependencies {
+  groovyCompiler 'org.apache.groovy:groovy:4.0.31'
+
   implementation 'io.nextflow:nf-lang:26.04.6'
   implementation 'org.apache.groovy:groovy:4.0.31'
-  implementation 'org.apache.groovy:groovy-ant:4.0.31'
-  implementation 'org.apache.groovy:groovy-astbuilder:4.0.31'
-  implementation 'org.apache.groovy:groovy-datetime:4.0.31'
-  implementation 'org.apache.groovy:groovy-dateutil:4.0.31'
-  implementation 'org.apache.groovy:groovy-groovydoc:4.0.31'
   implementation 'org.apache.groovy:groovy-json:4.0.31'
   implementation 'org.apache.groovy:groovy-yaml:4.0.31'
   implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.0'


### PR DESCRIPTION
While creating a package for NixOS/nixpkgs I discovered a few undeclared dependencies.  Builds using Nix happen in an isolated sandbox with no network connection.  Without these dependencies the build would fail.

It's not clear to me why builds succeed for others.  Perhaps these dependencies are cached or maybe just downloaded as needed.  Either way I thought I'd open a PR.
